### PR TITLE
feat: build staging orchestrator and neighborhood name sync

### DIFF
--- a/data/staging/run_all.py
+++ b/data/staging/run_all.py
@@ -1,0 +1,93 @@
+"""
+Orchestrator: run all staging transformations in sequence.
+
+Order:
+1. sync_neighborhoods (populate alternate name mappings)
+2. transform_neighborhoods (raw → stg)
+3. transform_crime (raw → stg)
+4. transform_crashes (raw → stg)
+5. transform_311 (raw → stg)
+6. transform_aqi (raw → stg)
+
+Partial failure tolerance — one transform failing doesn't block others.
+
+Usage:
+    python data/staging/run_all.py
+"""
+
+import logging
+import sys
+from datetime import datetime, timezone
+
+import sync_neighborhoods
+import transform_311
+import transform_aqi
+import transform_crashes
+import transform_crime
+import transform_neighborhoods
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger("staging_orchestrator")
+
+
+def main():
+    start = datetime.now(tz=timezone.utc)
+    logger.info("Starting staging transformations")
+    logger.info("=" * 60)
+
+    steps = [
+        ("sync_neighborhoods", sync_neighborhoods.sync),
+        ("stg_neighborhoods", transform_neighborhoods.transform),
+        ("stg_crime", transform_crime.transform),
+        ("stg_crashes", transform_crashes.transform),
+        ("stg_311", transform_311.transform),
+        ("stg_aqi", transform_aqi.transform),
+    ]
+
+    results = []
+    for name, func in steps:
+        logger.info(f"\n--- {name.upper()} ---")
+        try:
+            result = func()
+            results.append(result)
+            inserted = result.get("inserted", "-")
+            logger.info(f"{name}: {result['status']} — {inserted} records")
+        except Exception as e:
+            logger.error(f"{name}: FAILED — {e}", exc_info=True)
+            results.append({
+                "source": name,
+                "status": "error",
+                "error": str(e),
+            })
+
+    # Summary
+    elapsed = (datetime.now(tz=timezone.utc) - start).total_seconds()
+    logger.info("\n" + "=" * 60)
+    logger.info("STAGING SUMMARY")
+    logger.info("=" * 60)
+
+    has_errors = False
+    for r in results:
+        source = r.get("source", "unknown")
+        status = r.get("status", "unknown")
+        status_icon = "OK" if status == "ok" else "WARN" if status == "warning" else "FAIL"
+        inserted = r.get("inserted", "-")
+        logger.info(f"  [{status_icon:4s}] {source:25s} — {str(inserted):>8s} records")
+        if status == "error":
+            has_errors = True
+
+    logger.info(f"\n  Elapsed: {elapsed:.1f}s")
+
+    if has_errors:
+        logger.warning("Some transforms failed! Check logs above.")
+        return 1
+    else:
+        logger.info("All staging transforms completed successfully!")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/staging/sync_neighborhoods.py
+++ b/data/staging/sync_neighborhoods.py
@@ -1,0 +1,151 @@
+"""
+Sync ref_neighborhoods alternate name columns from raw data.
+
+Discovers actual neighborhood name variants used in each raw dataset
+and populates the corresponding columns in ref_neighborhoods:
+- crime_name  ← raw_crime.neighborhood_id
+- crash_name  ← raw_crashes.neighborhood_id
+- name_311    ← raw_311.neighborhood
+
+Uses case-insensitive fuzzy matching to map raw names to canonical names.
+"""
+
+import logging
+import time
+
+from db import get_connection
+
+logger = logging.getLogger(__name__)
+
+# (column_to_update, SQL to fetch distinct raw names)
+SOURCES = [
+    (
+        "crime_name",
+        "SELECT DISTINCT neighborhood_id AS name FROM raw_crime WHERE neighborhood_id IS NOT NULL",
+    ),
+    (
+        "crash_name",
+        "SELECT DISTINCT neighborhood_id AS name FROM raw_crashes WHERE neighborhood_id IS NOT NULL",
+    ),
+    (
+        "name_311",
+        "SELECT DISTINCT neighborhood AS name FROM raw_311 WHERE neighborhood IS NOT NULL",
+    ),
+]
+
+
+def _build_canonical_lookup(conn) -> dict[str, str]:
+    """Build lowercase canonical_name → canonical_name mapping."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT canonical_name FROM ref_neighborhoods")
+        rows = cur.fetchall()
+    return {name.lower().strip(): name for (name,) in rows}
+
+
+def _normalize_words(name: str) -> str:
+    """Reduce a name to sorted-ish space-separated words for fuzzy comparison."""
+    return " ".join(name.replace("-", " ").split())
+
+
+def _match_name(raw_name: str, lookup: dict[str, str]) -> str | None:
+    """Try to match a raw neighborhood name to a canonical name."""
+    key = raw_name.lower().strip()
+
+    # Exact match
+    if key in lookup:
+        return lookup[key]
+
+    # Try replacing hyphens with ' - '
+    normalized = key.replace("-", " - ").replace("  ", " ")
+    if normalized in lookup:
+        return lookup[normalized]
+
+    # Try removing hyphens entirely
+    no_hyphen = key.replace("-", " ").replace("  ", " ")
+    if no_hyphen in lookup:
+        return lookup[no_hyphen]
+
+    # Fuzzy: compare normalized word sequences
+    raw_words = _normalize_words(key)
+    for canonical_key, canonical_val in lookup.items():
+        if _normalize_words(canonical_key) == raw_words:
+            return canonical_val
+
+    return None
+
+
+def sync(dry_run: bool = False) -> dict:
+    """
+    Sync alternate neighborhood names from raw data into ref_neighborhoods.
+
+    Returns dict with counts of matched/unmatched names per source.
+    """
+    start = time.time()
+    logger.info("Starting neighborhood name sync")
+
+    conn = get_connection()
+    try:
+        lookup = _build_canonical_lookup(conn)
+        logger.info(f"  Loaded {len(lookup)} canonical neighborhoods")
+
+        results = {}
+
+        for col, query in SOURCES:
+            with conn.cursor() as cur:
+                cur.execute(query)
+                raw_names = [row[0] for row in cur.fetchall()]
+
+            matched = 0
+            unmatched_names = []
+
+            for raw_name in raw_names:
+                canonical = _match_name(raw_name, lookup)
+                if canonical:
+                    if not dry_run:
+                        with conn.cursor() as cur:
+                            cur.execute(
+                                f"UPDATE ref_neighborhoods SET {col} = %s "
+                                f"WHERE canonical_name = %s AND ({col} IS NULL OR {col} != %s)",
+                                (raw_name, canonical, raw_name),
+                            )
+                    matched += 1
+                else:
+                    unmatched_names.append(raw_name)
+
+            if not dry_run:
+                conn.commit()
+
+            results[col] = {
+                "total": len(raw_names),
+                "matched": matched,
+                "unmatched": len(unmatched_names),
+            }
+
+            if unmatched_names:
+                logger.warning(
+                    f"  {col}: {len(unmatched_names)} unmatched names: "
+                    f"{unmatched_names[:10]}{'...' if len(unmatched_names) > 10 else ''}"
+                )
+            else:
+                logger.info(f"  {col}: all {matched} names matched")
+
+    finally:
+        conn.close()
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  Neighborhood sync complete in {duration}s")
+
+    return {
+        "source": "sync_neighborhoods",
+        "status": "ok",
+        "results": results,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    result = sync()
+    print(f"Neighborhood sync: {result}")

--- a/data/staging/tests/test_run_all.py
+++ b/data/staging/tests/test_run_all.py
@@ -1,0 +1,59 @@
+"""Tests for staging orchestrator error handling."""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import run_all
+
+
+class TestOrchestratorPartialFailure:
+    """Verify orchestrator handles individual transform failures gracefully."""
+
+    @patch("run_all.transform_aqi")
+    @patch("run_all.transform_311")
+    @patch("run_all.transform_crashes")
+    @patch("run_all.transform_crime")
+    @patch("run_all.transform_neighborhoods")
+    @patch("run_all.sync_neighborhoods")
+    def test_one_failure_doesnt_block_others(
+        self, mock_sync, mock_nbhd, mock_crime, mock_crashes, mock_311, mock_aqi
+    ):
+        mock_sync.sync.return_value = {"source": "sync_neighborhoods", "status": "ok"}
+        mock_nbhd.transform.return_value = {"source": "stg_neighborhoods", "status": "ok", "inserted": 78}
+        mock_crime.transform.side_effect = RuntimeError("DB connection lost")
+        mock_crashes.transform.return_value = {"source": "stg_crashes", "status": "ok", "inserted": 500}
+        mock_311.transform.return_value = {"source": "stg_311", "status": "ok", "inserted": 1000}
+        mock_aqi.transform.return_value = {"source": "stg_aqi", "status": "ok", "inserted": 200}
+
+        exit_code = run_all.main()
+
+        # All transforms should have been called despite crime failure
+        mock_crashes.transform.assert_called_once()
+        mock_311.transform.assert_called_once()
+        mock_aqi.transform.assert_called_once()
+
+        # Exit code should be 1 (errors present)
+        assert exit_code == 1
+
+    @patch("run_all.transform_aqi")
+    @patch("run_all.transform_311")
+    @patch("run_all.transform_crashes")
+    @patch("run_all.transform_crime")
+    @patch("run_all.transform_neighborhoods")
+    @patch("run_all.sync_neighborhoods")
+    def test_all_success_returns_zero(
+        self, mock_sync, mock_nbhd, mock_crime, mock_crashes, mock_311, mock_aqi
+    ):
+        ok = {"status": "ok", "source": "test", "inserted": 100}
+        mock_sync.sync.return_value = {**ok, "source": "sync_neighborhoods"}
+        mock_nbhd.transform.return_value = {**ok, "source": "stg_neighborhoods"}
+        mock_crime.transform.return_value = {**ok, "source": "stg_crime"}
+        mock_crashes.transform.return_value = {**ok, "source": "stg_crashes"}
+        mock_311.transform.return_value = {**ok, "source": "stg_311"}
+        mock_aqi.transform.return_value = {**ok, "source": "stg_aqi"}
+
+        exit_code = run_all.main()
+        assert exit_code == 0

--- a/data/staging/tests/test_sync_neighborhoods.py
+++ b/data/staging/tests/test_sync_neighborhoods.py
@@ -1,0 +1,48 @@
+"""Tests for neighborhood name sync matching logic."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sync_neighborhoods import _match_name
+
+
+LOOKUP = {
+    "capitol hill": "Capitol Hill",
+    "five points": "Five Points",
+    "cbd": "CBD",
+    "baker": "Baker",
+    "cory - merrill": "Cory - Merrill",
+    "college view - south platte": "College View - South Platte",
+    "gateway - green valley ranch": "Gateway - Green Valley Ranch",
+    "elyria swansea": "Elyria Swansea",
+}
+
+
+class TestMatchName:
+    def test_exact_match(self):
+        assert _match_name("Capitol Hill", LOOKUP) == "Capitol Hill"
+
+    def test_case_insensitive(self):
+        assert _match_name("CAPITOL HILL", LOOKUP) == "Capitol Hill"
+        assert _match_name("capitol hill", LOOKUP) == "Capitol Hill"
+
+    def test_with_hyphens_to_spaced_hyphens(self):
+        # Raw data often uses "cory-merrill" instead of "cory - merrill"
+        assert _match_name("cory-merrill", LOOKUP) == "Cory - Merrill"
+
+    def test_hyphen_replacement_complex(self):
+        assert _match_name("gateway-green-valley-ranch", LOOKUP) is not None
+
+    def test_no_match(self):
+        assert _match_name("nonexistent-place", LOOKUP) is None
+
+    def test_empty_string(self):
+        assert _match_name("", LOOKUP) is None
+
+    def test_whitespace_trimmed(self):
+        assert _match_name("  baker  ", LOOKUP) == "Baker"
+
+    def test_simple_name(self):
+        assert _match_name("cbd", LOOKUP) == "CBD"


### PR DESCRIPTION
## Summary
- Add `data/staging/sync_neighborhoods.py` — discovers neighborhood name variants in raw data and populates ref_neighborhoods alternate name columns (crime_name, crash_name, name_311) with fuzzy matching
- Add `data/staging/run_all.py` — orchestrator running all 6 staging steps in order with partial failure tolerance and summary logging
- Add 10 tests for sync matching logic and orchestrator error handling

Closes #15

## Test plan
- [x] 68 total staging tests pass
- [x] ESLint + build pass
- [ ] Run `python data/staging/run_all.py` against real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)