### PR TITLE
feat: build mart layer — neighborhood analytics and rankings

### DIFF
--- a/data/marts/build_city_pulse_neighborhood.py
+++ b/data/marts/build_city_pulse_neighborhood.py
@@ -1,0 +1,141 @@
+"""
+Build mart_city_pulse_neighborhood — per-neighborhood totals and deltas.
+
+For each (neighborhood, period): count crime/crashes/311, compute total,
+compute delta_pct vs prior period of same length.
+
+Periods: 7d, 30d, 90d
+Delta: ((current - prior) / prior) * 100, NULL if prior = 0.
+"""
+
+import logging
+import time
+
+from db import execute_sql, truncate_table
+
+logger = logging.getLogger(__name__)
+
+# Template SQL for one period
+PERIOD_SQL = """
+INSERT INTO mart_city_pulse_neighborhood (
+    neighborhood, period,
+    crime_count, crash_count, requests_311_count, total_incidents,
+    crime_delta_pct, crash_delta_pct, requests_311_delta_pct, total_delta_pct,
+    updated_at
+)
+SELECT
+    n.neighborhood,
+    %(period)s AS period,
+    COALESCE(cur.crime, 0),
+    COALESCE(cur.crashes, 0),
+    COALESCE(cur.r311, 0),
+    COALESCE(cur.crime, 0) + COALESCE(cur.crashes, 0) + COALESCE(cur.r311, 0),
+    CASE WHEN COALESCE(prev.crime, 0) > 0
+         THEN ROUND(((COALESCE(cur.crime, 0) - prev.crime)::numeric / prev.crime) * 100, 1)
+         ELSE NULL END,
+    CASE WHEN COALESCE(prev.crashes, 0) > 0
+         THEN ROUND(((COALESCE(cur.crashes, 0) - prev.crashes)::numeric / prev.crashes) * 100, 1)
+         ELSE NULL END,
+    CASE WHEN COALESCE(prev.r311, 0) > 0
+         THEN ROUND(((COALESCE(cur.r311, 0) - prev.r311)::numeric / prev.r311) * 100, 1)
+         ELSE NULL END,
+    CASE WHEN (COALESCE(prev.crime, 0) + COALESCE(prev.crashes, 0) + COALESCE(prev.r311, 0)) > 0
+         THEN ROUND((
+             (COALESCE(cur.crime, 0) + COALESCE(cur.crashes, 0) + COALESCE(cur.r311, 0))
+             - (COALESCE(prev.crime, 0) + COALESCE(prev.crashes, 0) + COALESCE(prev.r311, 0))
+         )::numeric / (COALESCE(prev.crime, 0) + COALESCE(prev.crashes, 0) + COALESCE(prev.r311, 0)) * 100, 1)
+         ELSE NULL END,
+    NOW()
+FROM (
+    SELECT canonical_name AS neighborhood FROM ref_neighborhoods
+) n
+LEFT JOIN (
+    -- Current period counts
+    SELECT neighborhood,
+           SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
+           SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
+           SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
+    FROM (
+        SELECT neighborhood, 'crime' AS src FROM stg_crime
+        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, 'crashes' FROM stg_crashes
+        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, '311' FROM stg_311
+        WHERE case_created_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+    ) cur_all
+    GROUP BY neighborhood
+) cur ON cur.neighborhood = n.neighborhood
+LEFT JOIN (
+    -- Prior period counts (same length, immediately before)
+    SELECT neighborhood,
+           SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
+           SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
+           SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
+    FROM (
+        SELECT neighborhood, 'crime' AS src FROM stg_crime
+        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
+          AND reported_date < CURRENT_DATE - %(days)s
+          AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, 'crashes' FROM stg_crashes
+        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
+          AND reported_date < CURRENT_DATE - %(days)s
+          AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, '311' FROM stg_311
+        WHERE case_created_date >= CURRENT_DATE - %(days)s * 2
+          AND case_created_date < CURRENT_DATE - %(days)s
+          AND neighborhood IS NOT NULL
+    ) prev_all
+    GROUP BY neighborhood
+) prev ON prev.neighborhood = n.neighborhood
+ON CONFLICT (neighborhood, period) DO UPDATE SET
+    crime_count = EXCLUDED.crime_count,
+    crash_count = EXCLUDED.crash_count,
+    requests_311_count = EXCLUDED.requests_311_count,
+    total_incidents = EXCLUDED.total_incidents,
+    crime_delta_pct = EXCLUDED.crime_delta_pct,
+    crash_delta_pct = EXCLUDED.crash_delta_pct,
+    requests_311_delta_pct = EXCLUDED.requests_311_delta_pct,
+    total_delta_pct = EXCLUDED.total_delta_pct,
+    updated_at = NOW()
+"""
+
+PERIODS = [
+    ("7d", 7),
+    ("30d", 30),
+    ("90d", 90),
+]
+
+
+def build() -> dict:
+    """Build the mart_city_pulse_neighborhood table."""
+    start = time.time()
+    logger.info("Building mart_city_pulse_neighborhood")
+
+    truncate_table("mart_city_pulse_neighborhood")
+    total_rows = 0
+    for period_label, days in PERIODS:
+        rows = execute_sql(PERIOD_SQL, {"period": period_label, "days": days})
+        total_rows += rows
+        logger.info(f"  Period {period_label}: {rows} rows")
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  mart_city_pulse_neighborhood: {total_rows} rows in {duration}s")
+
+    return {
+        "source": "mart_city_pulse_neighborhood",
+        "status": "ok",
+        "inserted": total_rows,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    result = build()
+    print(f"City pulse neighborhood: {result}")

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -1,0 +1,132 @@
+"""
+Build mart_neighborhood_comparison — rates per area and deltas.
+
+For each (period, neighborhood): compute rates (incidents per sq unit from
+stg_neighborhoods.shape_area), compute delta_pct vs prior period.
+
+Periods: 7d, 30d, 90d
+"""
+
+import logging
+import time
+
+from db import execute_sql, truncate_table
+
+logger = logging.getLogger(__name__)
+
+COMPARISON_SQL = """
+INSERT INTO mart_neighborhood_comparison (
+    period, neighborhood,
+    crime_rate, crash_rate, requests_311_rate,
+    crime_delta_pct, crash_delta_pct, requests_311_delta_pct,
+    updated_at
+)
+SELECT
+    %(period)s AS period,
+    n.nbhd_name AS neighborhood,
+    CASE WHEN n.shape_area > 0
+         THEN ROUND((COALESCE(cur.crime, 0)::numeric / n.shape_area) * 1000000, 4)
+         ELSE 0 END,
+    CASE WHEN n.shape_area > 0
+         THEN ROUND((COALESCE(cur.crashes, 0)::numeric / n.shape_area) * 1000000, 4)
+         ELSE 0 END,
+    CASE WHEN n.shape_area > 0
+         THEN ROUND((COALESCE(cur.r311, 0)::numeric / n.shape_area) * 1000000, 4)
+         ELSE 0 END,
+    CASE WHEN COALESCE(prev.crime, 0) > 0
+         THEN ROUND(((COALESCE(cur.crime, 0) - prev.crime)::numeric / prev.crime) * 100, 1)
+         ELSE NULL END,
+    CASE WHEN COALESCE(prev.crashes, 0) > 0
+         THEN ROUND(((COALESCE(cur.crashes, 0) - prev.crashes)::numeric / prev.crashes) * 100, 1)
+         ELSE NULL END,
+    CASE WHEN COALESCE(prev.r311, 0) > 0
+         THEN ROUND(((COALESCE(cur.r311, 0) - prev.r311)::numeric / prev.r311) * 100, 1)
+         ELSE NULL END,
+    NOW()
+FROM stg_neighborhoods n
+LEFT JOIN (
+    SELECT neighborhood,
+           SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
+           SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
+           SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
+    FROM (
+        SELECT neighborhood, 'crime' AS src FROM stg_crime
+        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, 'crashes' FROM stg_crashes
+        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, '311' FROM stg_311
+        WHERE case_created_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+    ) cur_all
+    GROUP BY neighborhood
+) cur ON cur.neighborhood = n.nbhd_name
+LEFT JOIN (
+    SELECT neighborhood,
+           SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
+           SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
+           SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
+    FROM (
+        SELECT neighborhood, 'crime' AS src FROM stg_crime
+        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
+          AND reported_date < CURRENT_DATE - %(days)s
+          AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, 'crashes' FROM stg_crashes
+        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
+          AND reported_date < CURRENT_DATE - %(days)s
+          AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, '311' FROM stg_311
+        WHERE case_created_date >= CURRENT_DATE - %(days)s * 2
+          AND case_created_date < CURRENT_DATE - %(days)s
+          AND neighborhood IS NOT NULL
+    ) prev_all
+    GROUP BY neighborhood
+) prev ON prev.neighborhood = n.nbhd_name
+ON CONFLICT (period, neighborhood) DO UPDATE SET
+    crime_rate = EXCLUDED.crime_rate,
+    crash_rate = EXCLUDED.crash_rate,
+    requests_311_rate = EXCLUDED.requests_311_rate,
+    crime_delta_pct = EXCLUDED.crime_delta_pct,
+    crash_delta_pct = EXCLUDED.crash_delta_pct,
+    requests_311_delta_pct = EXCLUDED.requests_311_delta_pct,
+    updated_at = NOW()
+"""
+
+PERIODS = [
+    ("7d", 7),
+    ("30d", 30),
+    ("90d", 90),
+]
+
+
+def build() -> dict:
+    """Build the mart_neighborhood_comparison table."""
+    start = time.time()
+    logger.info("Building mart_neighborhood_comparison")
+
+    truncate_table("mart_neighborhood_comparison")
+    total_rows = 0
+    for period_label, days in PERIODS:
+        rows = execute_sql(COMPARISON_SQL, {"period": period_label, "days": days})
+        total_rows += rows
+        logger.info(f"  Period {period_label}: {rows} rows")
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  mart_neighborhood_comparison: {total_rows} rows in {duration}s")
+
+    return {
+        "source": "mart_neighborhood_comparison",
+        "status": "ok",
+        "inserted": total_rows,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    result = build()
+    print(f"Neighborhood comparison: {result}")

--- a/data/marts/build_neighborhood_ranking.py
+++ b/data/marts/build_neighborhood_ranking.py
@@ -1,0 +1,129 @@
+"""
+Build mart_neighborhood_ranking — ranked neighborhoods by composite score.
+
+For each (period, neighborhood): count by domain, compute composite_score
+(min-max normalized sum), assign rank. Higher score = more pressure.
+
+Periods: 7d, 30d, 90d
+"""
+
+import logging
+import time
+
+from db import execute_sql, truncate_table
+
+logger = logging.getLogger(__name__)
+
+# Two-step: first insert raw counts, then update with normalized scores and ranks
+INSERT_COUNTS_SQL = """
+INSERT INTO mart_neighborhood_ranking (
+    period, neighborhood,
+    crime_count, crash_count, requests_311_count,
+    composite_score, rank, updated_at
+)
+SELECT
+    %(period)s AS period,
+    n.canonical_name AS neighborhood,
+    COALESCE(c.crime, 0),
+    COALESCE(c.crashes, 0),
+    COALESCE(c.r311, 0),
+    0,  -- placeholder, updated below
+    0,  -- placeholder
+    NOW()
+FROM ref_neighborhoods n
+LEFT JOIN (
+    SELECT neighborhood,
+           SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
+           SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
+           SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
+    FROM (
+        SELECT neighborhood, 'crime' AS src FROM stg_crime
+        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, 'crashes' FROM stg_crashes
+        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        UNION ALL
+        SELECT neighborhood, '311' FROM stg_311
+        WHERE case_created_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+    ) all_src
+    GROUP BY neighborhood
+) c ON c.neighborhood = n.canonical_name
+ON CONFLICT (period, neighborhood) DO UPDATE SET
+    crime_count = EXCLUDED.crime_count,
+    crash_count = EXCLUDED.crash_count,
+    requests_311_count = EXCLUDED.requests_311_count,
+    updated_at = NOW()
+"""
+
+# Normalize each domain 0-1 across neighborhoods, sum for composite score
+UPDATE_SCORES_SQL = """
+WITH stats AS (
+    SELECT
+        period,
+        NULLIF(MAX(crime_count), 0) AS max_crime,
+        NULLIF(MAX(crash_count), 0) AS max_crash,
+        NULLIF(MAX(requests_311_count), 0) AS max_311
+    FROM mart_neighborhood_ranking
+    WHERE period = %(period)s
+    GROUP BY period
+),
+scored AS (
+    SELECT
+        r.id,
+        COALESCE(r.crime_count::numeric / s.max_crime, 0) +
+        COALESCE(r.crash_count::numeric / s.max_crash, 0) +
+        COALESCE(r.requests_311_count::numeric / s.max_311, 0) AS score
+    FROM mart_neighborhood_ranking r
+    CROSS JOIN stats s
+    WHERE r.period = %(period)s
+),
+ranked AS (
+    SELECT id, score,
+           ROW_NUMBER() OVER (ORDER BY score DESC) AS rnk
+    FROM scored
+)
+UPDATE mart_neighborhood_ranking r
+SET composite_score = ROUND(rk.score::numeric, 3),
+    rank = rk.rnk,
+    updated_at = NOW()
+FROM ranked rk
+WHERE r.id = rk.id
+"""
+
+PERIODS = [
+    ("7d", 7),
+    ("30d", 30),
+    ("90d", 90),
+]
+
+
+def build() -> dict:
+    """Build the mart_neighborhood_ranking table."""
+    start = time.time()
+    logger.info("Building mart_neighborhood_ranking")
+
+    truncate_table("mart_neighborhood_ranking")
+    total_rows = 0
+    for period_label, days in PERIODS:
+        rows = execute_sql(INSERT_COUNTS_SQL, {"period": period_label, "days": days})
+        execute_sql(UPDATE_SCORES_SQL, {"period": period_label})
+        total_rows += rows
+        logger.info(f"  Period {period_label}: {rows} rows, scores computed")
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  mart_neighborhood_ranking: {total_rows} rows in {duration}s")
+
+    return {
+        "source": "mart_neighborhood_ranking",
+        "status": "ok",
+        "inserted": total_rows,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    result = build()
+    print(f"Neighborhood ranking: {result}")

--- a/data/marts/tests/test_build_neighborhood.py
+++ b/data/marts/tests/test_build_neighborhood.py
@@ -1,0 +1,84 @@
+"""Tests for neighborhood mart build scripts — SQL structure validation."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "staging"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from build_city_pulse_neighborhood import PERIOD_SQL as NBHD_SQL, PERIODS as NBHD_PERIODS
+from build_neighborhood_ranking import INSERT_COUNTS_SQL, UPDATE_SCORES_SQL, PERIODS as RANK_PERIODS
+from build_neighborhood_comparison import COMPARISON_SQL, PERIODS as COMP_PERIODS
+
+
+class TestCityPulseNeighborhoodSQL:
+    def test_inserts_into_correct_table(self):
+        assert "INSERT INTO mart_city_pulse_neighborhood" in NBHD_SQL
+
+    def test_has_upsert(self):
+        assert "ON CONFLICT (neighborhood, period) DO UPDATE" in NBHD_SQL
+
+    def test_queries_all_three_domains(self):
+        assert "stg_crime" in NBHD_SQL
+        assert "stg_crashes" in NBHD_SQL
+        assert "stg_311" in NBHD_SQL
+
+    def test_computes_delta(self):
+        assert "delta" in NBHD_SQL.lower()
+
+    def test_uses_prior_period(self):
+        # Prior period = days*2 back to days back
+        assert "%(days)s * 2" in NBHD_SQL
+
+    def test_three_periods(self):
+        assert len(NBHD_PERIODS) == 3
+        labels = [p[0] for p in NBHD_PERIODS]
+        assert "7d" in labels
+        assert "30d" in labels
+        assert "90d" in labels
+
+    def test_handles_zero_division(self):
+        # Should have CASE WHEN ... > 0 to avoid div by zero
+        assert "> 0" in NBHD_SQL
+
+
+class TestNeighborhoodRankingSQL:
+    def test_inserts_into_correct_table(self):
+        assert "INSERT INTO mart_neighborhood_ranking" in INSERT_COUNTS_SQL
+
+    def test_has_upsert(self):
+        assert "ON CONFLICT (period, neighborhood) DO UPDATE" in INSERT_COUNTS_SQL
+
+    def test_update_computes_scores(self):
+        assert "composite_score" in UPDATE_SCORES_SQL
+
+    def test_update_assigns_rank(self):
+        assert "ROW_NUMBER()" in UPDATE_SCORES_SQL
+
+    def test_normalizes_per_domain(self):
+        assert "max_crime" in UPDATE_SCORES_SQL
+        assert "max_crash" in UPDATE_SCORES_SQL
+        assert "max_311" in UPDATE_SCORES_SQL
+
+    def test_three_periods(self):
+        assert len(RANK_PERIODS) == 3
+
+
+class TestNeighborhoodComparisonSQL:
+    def test_inserts_into_correct_table(self):
+        assert "INSERT INTO mart_neighborhood_comparison" in COMPARISON_SQL
+
+    def test_has_upsert(self):
+        assert "ON CONFLICT (period, neighborhood) DO UPDATE" in COMPARISON_SQL
+
+    def test_computes_rates_per_area(self):
+        assert "shape_area" in COMPARISON_SQL
+
+    def test_computes_deltas(self):
+        assert "delta_pct" in COMPARISON_SQL.lower()
+
+    def test_handles_zero_area(self):
+        assert "shape_area > 0" in COMPARISON_SQL
+
+    def test_three_periods(self):
+        assert len(COMP_PERIODS) == 3


### PR DESCRIPTION
## Summary
- Add `build_city_pulse_neighborhood.py` — per-neighborhood totals + delta_pct vs prior period (7d/30d/90d)
- Add `build_neighborhood_ranking.py` — min-max normalized composite score + rank across neighborhoods
- Add `build_neighborhood_comparison.py` — incident rates per area (shape_area) + deltas
- All use parameterized SQL with UPSERT, handle division by zero
- Add 19 SQL structure validation tests

Closes #17

## Test plan
- [x] 39 mart tests pass
- [x] ESLint + build pass
- [ ] Run against real data, verify rankings match manual spot-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)