### PR TITLE
feat: build mart layer — heatmap, category breakdown, narrative signals

### DIFF
--- a/data/marts/build_category_breakdown.py
+++ b/data/marts/build_category_breakdown.py
@@ -1,0 +1,101 @@
+"""
+Build mart_category_breakdown — counts and percentages by category.
+
+For each (period, domain, category): count incidents, compute pct_of_total.
+
+Periods: 7d, 30d, 90d
+"""
+
+import logging
+import time
+
+from db import execute_sql, truncate_table
+
+logger = logging.getLogger(__name__)
+
+# Insert counts first, then update percentages
+INSERT_SQL = """
+INSERT INTO mart_category_breakdown (
+    period, domain, category, count, pct_of_total, updated_at
+)
+-- Crime by offense_category
+SELECT
+    %(period)s, 'crime',
+    COALESCE(offense_category, 'Unknown'),
+    COUNT(*), 0, NOW()
+FROM stg_crime
+WHERE reported_date >= CURRENT_DATE - %(days)s
+GROUP BY offense_category
+
+UNION ALL
+
+-- Crashes by top_offense
+SELECT
+    %(period)s, 'crashes',
+    COALESCE(top_offense, 'Unknown'),
+    COUNT(*), 0, NOW()
+FROM stg_crashes
+WHERE reported_date >= CURRENT_DATE - %(days)s
+GROUP BY top_offense
+
+UNION ALL
+
+-- 311 by request_type
+SELECT
+    %(period)s, '311',
+    COALESCE(request_type, 'Unknown'),
+    COUNT(*), 0, NOW()
+FROM stg_311
+WHERE case_created_date >= CURRENT_DATE - %(days)s
+GROUP BY request_type
+
+ON CONFLICT (period, domain, category) DO UPDATE SET
+    count = EXCLUDED.count,
+    updated_at = NOW()
+"""
+
+UPDATE_PCT_SQL = """
+UPDATE mart_category_breakdown cb
+SET pct_of_total = ROUND(
+    cb.count::numeric / NULLIF(totals.total, 0) * 100, 1
+)
+FROM (
+    SELECT period, domain, SUM(count) AS total
+    FROM mart_category_breakdown
+    WHERE period = %(period)s
+    GROUP BY period, domain
+) totals
+WHERE cb.period = totals.period
+  AND cb.domain = totals.domain
+  AND cb.period = %(period)s
+"""
+
+PERIODS = [("7d", 7), ("30d", 30), ("90d", 90)]
+
+
+def build() -> dict:
+    start = time.time()
+    logger.info("Building mart_category_breakdown")
+
+    truncate_table("mart_category_breakdown")
+    total_rows = 0
+    for period_label, days in PERIODS:
+        rows = execute_sql(INSERT_SQL, {"period": period_label, "days": days})
+        execute_sql(UPDATE_PCT_SQL, {"period": period_label})
+        total_rows += rows
+        logger.info(f"  Period {period_label}: {rows} rows")
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  mart_category_breakdown: {total_rows} rows in {duration}s")
+
+    return {
+        "source": "mart_category_breakdown",
+        "status": "ok",
+        "inserted": total_rows,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    print(f"Category breakdown: {build()}")

--- a/data/marts/build_heatmap.py
+++ b/data/marts/build_heatmap.py
@@ -1,0 +1,99 @@
+"""
+Build mart_heatmap_hour_day — incident counts by hour × day-of-week.
+
+For each (period, domain, day_of_week, hour_of_day): count incidents.
+day_of_week: 0=Mon..6=Sun. Uses Denver local time for extraction.
+
+Periods: 7d, 30d, 90d
+"""
+
+import logging
+import time
+
+from db import execute_sql, truncate_table
+
+logger = logging.getLogger(__name__)
+
+HEATMAP_SQL = """
+INSERT INTO mart_heatmap_hour_day (
+    period, domain, day_of_week, hour_of_day, count, updated_at
+)
+-- Crime
+SELECT
+    %(period)s,
+    'crime',
+    EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver')::smallint - 1,
+    EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint,
+    COUNT(*),
+    NOW()
+FROM stg_crime
+WHERE reported_date >= CURRENT_DATE - %(days)s
+GROUP BY
+    EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
+    EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
+
+UNION ALL
+
+-- Crashes
+SELECT
+    %(period)s,
+    'crashes',
+    EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver')::smallint - 1,
+    EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint,
+    COUNT(*),
+    NOW()
+FROM stg_crashes
+WHERE reported_date >= CURRENT_DATE - %(days)s
+GROUP BY
+    EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
+    EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
+
+UNION ALL
+
+-- 311
+SELECT
+    %(period)s,
+    '311',
+    EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver')::smallint - 1,
+    EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')::smallint,
+    COUNT(*),
+    NOW()
+FROM stg_311
+WHERE case_created_date >= CURRENT_DATE - %(days)s
+GROUP BY
+    EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver'),
+    EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')
+
+ON CONFLICT (period, domain, day_of_week, hour_of_day) DO UPDATE SET
+    count = EXCLUDED.count,
+    updated_at = NOW()
+"""
+
+PERIODS = [("7d", 7), ("30d", 30), ("90d", 90)]
+
+
+def build() -> dict:
+    start = time.time()
+    logger.info("Building mart_heatmap_hour_day")
+
+    truncate_table("mart_heatmap_hour_day")
+    total_rows = 0
+    for period_label, days in PERIODS:
+        rows = execute_sql(HEATMAP_SQL, {"period": period_label, "days": days})
+        total_rows += rows
+        logger.info(f"  Period {period_label}: {rows} rows")
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  mart_heatmap_hour_day: {total_rows} rows in {duration}s")
+
+    return {
+        "source": "mart_heatmap_hour_day",
+        "status": "ok",
+        "inserted": total_rows,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    print(f"Heatmap: {build()}")

--- a/data/marts/build_narrative_signals.py
+++ b/data/marts/build_narrative_signals.py
@@ -1,0 +1,160 @@
+"""
+Build mart_narrative_signals — top signals for template narrative blocks.
+
+Signals per period:
+- top_domain: which domain had largest delta increase
+- top_neighborhood: highest composite score neighborhood
+- top_category: most frequent category in the top domain
+- aqi_status: current AQI level and value
+- most_improved: neighborhood with largest negative delta
+
+Periods: 7d, 30d, 90d
+"""
+
+import logging
+import time
+
+from db import execute_sql, truncate_table
+
+logger = logging.getLogger(__name__)
+
+# Each signal is a separate INSERT using data from other marts
+SIGNALS = [
+    # top_domain: domain with highest total delta
+    (
+        "top_domain",
+        """
+        INSERT INTO mart_narrative_signals (period, signal_type, signal_key, signal_value, signal_numeric, rank, updated_at)
+        SELECT %(period)s, 'top_domain', domain, domain,
+               delta_pct, 1, NOW()
+        FROM (
+            SELECT 'crime' AS domain,
+                   AVG(crime_delta_pct) AS delta_pct
+            FROM mart_city_pulse_neighborhood WHERE period = %(period)s AND crime_delta_pct IS NOT NULL
+            UNION ALL
+            SELECT 'crashes',
+                   AVG(crash_delta_pct)
+            FROM mart_city_pulse_neighborhood WHERE period = %(period)s AND crash_delta_pct IS NOT NULL
+            UNION ALL
+            SELECT '311',
+                   AVG(requests_311_delta_pct)
+            FROM mart_city_pulse_neighborhood WHERE period = %(period)s AND requests_311_delta_pct IS NOT NULL
+        ) domains
+        ORDER BY delta_pct DESC NULLS LAST
+        LIMIT 1
+        ON CONFLICT (period, signal_type, rank) DO UPDATE SET
+            signal_key = EXCLUDED.signal_key,
+            signal_value = EXCLUDED.signal_value,
+            signal_numeric = EXCLUDED.signal_numeric,
+            updated_at = NOW()
+        """,
+    ),
+    # top_neighborhood: highest composite score
+    (
+        "top_neighborhood",
+        """
+        INSERT INTO mart_narrative_signals (period, signal_type, signal_key, signal_value, signal_numeric, rank, updated_at)
+        SELECT %(period)s, 'top_neighborhood', neighborhood, neighborhood,
+               composite_score, 1, NOW()
+        FROM mart_neighborhood_ranking
+        WHERE period = %(period)s AND rank = 1
+        LIMIT 1
+        ON CONFLICT (period, signal_type, rank) DO UPDATE SET
+            signal_key = EXCLUDED.signal_key,
+            signal_value = EXCLUDED.signal_value,
+            signal_numeric = EXCLUDED.signal_numeric,
+            updated_at = NOW()
+        """,
+    ),
+    # top_category: most frequent category across all domains
+    (
+        "top_category",
+        """
+        INSERT INTO mart_narrative_signals (period, signal_type, signal_key, signal_value, signal_numeric, rank, updated_at)
+        SELECT %(period)s, 'top_category',
+               domain || ':' || category,
+               category,
+               count, 1, NOW()
+        FROM mart_category_breakdown
+        WHERE period = %(period)s
+        ORDER BY count DESC
+        LIMIT 1
+        ON CONFLICT (period, signal_type, rank) DO UPDATE SET
+            signal_key = EXCLUDED.signal_key,
+            signal_value = EXCLUDED.signal_value,
+            signal_numeric = EXCLUDED.signal_numeric,
+            updated_at = NOW()
+        """,
+    ),
+    # aqi_status: latest AQI reading
+    (
+        "aqi_status",
+        """
+        INSERT INTO mart_narrative_signals (period, signal_type, signal_key, signal_value, signal_numeric, rank, updated_at)
+        SELECT %(period)s, 'aqi_status',
+               category,
+               category || ' (' || aqi_max || ')',
+               aqi_max, 1, NOW()
+        FROM mart_aqi_daily
+        WHERE aqi_max IS NOT NULL
+        ORDER BY date DESC
+        LIMIT 1
+        ON CONFLICT (period, signal_type, rank) DO UPDATE SET
+            signal_key = EXCLUDED.signal_key,
+            signal_value = EXCLUDED.signal_value,
+            signal_numeric = EXCLUDED.signal_numeric,
+            updated_at = NOW()
+        """,
+    ),
+    # most_improved: neighborhood with largest negative total_delta_pct
+    (
+        "most_improved",
+        """
+        INSERT INTO mart_narrative_signals (period, signal_type, signal_key, signal_value, signal_numeric, rank, updated_at)
+        SELECT %(period)s, 'most_improved', neighborhood, neighborhood,
+               total_delta_pct, 1, NOW()
+        FROM mart_city_pulse_neighborhood
+        WHERE period = %(period)s AND total_delta_pct IS NOT NULL AND total_delta_pct < 0
+        ORDER BY total_delta_pct ASC
+        LIMIT 1
+        ON CONFLICT (period, signal_type, rank) DO UPDATE SET
+            signal_key = EXCLUDED.signal_key,
+            signal_value = EXCLUDED.signal_value,
+            signal_numeric = EXCLUDED.signal_numeric,
+            updated_at = NOW()
+        """,
+    ),
+]
+
+PERIODS = [("7d", 7), ("30d", 30), ("90d", 90)]
+
+
+def build() -> dict:
+    start = time.time()
+    logger.info("Building mart_narrative_signals")
+
+    truncate_table("mart_narrative_signals")
+    total_rows = 0
+    for period_label, _ in PERIODS:
+        for signal_name, sql in SIGNALS:
+            try:
+                rows = execute_sql(sql, {"period": period_label})
+                total_rows += rows
+            except Exception as e:
+                logger.warning(f"  Signal {signal_name}/{period_label} failed: {e}")
+        logger.info(f"  Period {period_label}: signals computed")
+
+    duration = round(time.time() - start, 1)
+    logger.info(f"  mart_narrative_signals: {total_rows} rows in {duration}s")
+
+    return {
+        "source": "mart_narrative_signals",
+        "status": "ok",
+        "inserted": total_rows,
+        "duration_s": duration,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    print(f"Narrative signals: {build()}")

--- a/data/marts/tests/test_build_heatmap_signals.py
+++ b/data/marts/tests/test_build_heatmap_signals.py
@@ -1,0 +1,90 @@
+"""Tests for heatmap, category breakdown, and narrative signals SQL."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "staging"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from build_heatmap import HEATMAP_SQL, PERIODS as HM_PERIODS
+from build_category_breakdown import INSERT_SQL as CAT_SQL, UPDATE_PCT_SQL, PERIODS as CAT_PERIODS
+from build_narrative_signals import SIGNALS, PERIODS as SIG_PERIODS
+
+
+class TestHeatmapSQL:
+    def test_inserts_into_correct_table(self):
+        assert "INSERT INTO mart_heatmap_hour_day" in HEATMAP_SQL
+
+    def test_has_upsert(self):
+        assert "ON CONFLICT (period, domain, day_of_week, hour_of_day) DO UPDATE" in HEATMAP_SQL
+
+    def test_uses_denver_timezone(self):
+        assert "America/Denver" in HEATMAP_SQL
+
+    def test_extracts_isodow(self):
+        assert "ISODOW" in HEATMAP_SQL
+
+    def test_extracts_hour(self):
+        assert "EXTRACT(HOUR" in HEATMAP_SQL
+
+    def test_all_three_domains(self):
+        assert "'crime'" in HEATMAP_SQL
+        assert "'crashes'" in HEATMAP_SQL
+        assert "'311'" in HEATMAP_SQL
+
+    def test_three_periods(self):
+        assert len(HM_PERIODS) == 3
+
+
+class TestCategoryBreakdownSQL:
+    def test_inserts_into_correct_table(self):
+        assert "INSERT INTO mart_category_breakdown" in CAT_SQL
+
+    def test_has_upsert(self):
+        assert "ON CONFLICT (period, domain, category) DO UPDATE" in CAT_SQL
+
+    def test_all_three_domains(self):
+        assert "'crime'" in CAT_SQL
+        assert "'crashes'" in CAT_SQL
+        assert "'311'" in CAT_SQL
+
+    def test_update_computes_percentage(self):
+        assert "pct_of_total" in UPDATE_PCT_SQL
+        assert "NULLIF" in UPDATE_PCT_SQL  # handles zero division
+
+    def test_three_periods(self):
+        assert len(CAT_PERIODS) == 3
+
+
+class TestNarrativeSignals:
+    def test_has_all_five_signal_types(self):
+        signal_names = [s[0] for s in SIGNALS]
+        assert "top_domain" in signal_names
+        assert "top_neighborhood" in signal_names
+        assert "top_category" in signal_names
+        assert "aqi_status" in signal_names
+        assert "most_improved" in signal_names
+
+    def test_all_signals_have_upsert(self):
+        for name, sql in SIGNALS:
+            assert "ON CONFLICT" in sql, f"Signal {name} missing upsert"
+
+    def test_top_domain_uses_delta(self):
+        sql = next(s[1] for s in SIGNALS if s[0] == "top_domain")
+        assert "delta_pct" in sql
+
+    def test_top_neighborhood_uses_ranking(self):
+        sql = next(s[1] for s in SIGNALS if s[0] == "top_neighborhood")
+        assert "mart_neighborhood_ranking" in sql
+        assert "rank = 1" in sql
+
+    def test_aqi_status_uses_aqi_daily(self):
+        sql = next(s[1] for s in SIGNALS if s[0] == "aqi_status")
+        assert "mart_aqi_daily" in sql
+
+    def test_most_improved_filters_negative(self):
+        sql = next(s[1] for s in SIGNALS if s[0] == "most_improved")
+        assert "< 0" in sql
+
+    def test_three_periods(self):
+        assert len(SIG_PERIODS) == 3


### PR DESCRIPTION
## Summary
- Add `build_heatmap.py` — hour × day-of-week matrix using Denver timezone (ISODOW), 3 domains × 3 periods
- Add `build_category_breakdown.py` — counts + pct_of_total per (period, domain, category) with NULLIF zero-division guard
- Add `build_narrative_signals.py` — 5 signal types (top_domain, top_neighborhood, top_category, aqi_status, most_improved) derived from other marts
- Add 19 SQL structure tests

Closes #18

## Test plan
- [x] 19 tests pass
- [x] ESLint + build pass
- [ ] Run against real data and verify signal quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)