### PR TITLE
feat: set up Railway cron job for daily refresh (closes #20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,14 @@ Public BI dashboard built on live Denver open data (crime, traffic crashes, 311 
 - `npm test` — Jest tests
 - `npm start` — start production server
 
+## Daily Pipeline (Railway Cron)
+- Schedule: every day at 06:00 UTC (midnight Denver MDT)
+- Entry point: `python data/pipeline/run_daily.py`
+- Docker image: `data/pipeline/Dockerfile` (python:3.12-slim)
+- Railway config: `data/pipeline/railway.json`
+- Timeout: 30 min (per-step timeout: 10 min)
+- Pipeline steps: migrations → ingestion → sync neighborhoods → staging → marts
+
 ## Rules
 - Follow workflow: PRD → Design → Phases → Plan → Issues → Code → Review
 - Never push to main directly — PRs only

--- a/data/pipeline/Dockerfile
+++ b/data/pipeline/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy all data scripts
+COPY . .
+
+CMD ["python", "pipeline/run_daily.py"]

--- a/data/pipeline/railway.json
+++ b/data/pipeline/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "data/pipeline/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "python data/pipeline/run_daily.py",
+    "cronSchedule": "0 6 * * *",
+    "healthcheckPath": null,
+    "restartPolicyType": "NEVER",
+    "restartPolicyMaxRetries": 0
+  }
+}


### PR DESCRIPTION
## Summary
- Add `data/pipeline/Dockerfile` — Python 3.12-slim image that runs the daily pipeline
- Add `data/pipeline/railway.json` — Railway cron config scheduled at 06:00 UTC (midnight Denver MDT)
- Update `CLAUDE.md` with daily pipeline cron documentation

## Test plan
- [x] Existing staging tests pass (72/72)
- [x] Existing pipeline tests pass
- [ ] Verify Railway deploys the cron service from this config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)