### PR TITLE
feat: build City Pulse API routes (closes #34)

### DIFF
--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -1,0 +1,178 @@
+jest.mock("next/server", () => {
+  return {
+    NextRequest: class {
+      nextUrl: URL;
+      constructor(url: string) {
+        this.nextUrl = new URL(url);
+      }
+    },
+    NextResponse: {
+      json: (
+        body: unknown,
+        init?: { status?: number; headers?: Record<string, string> }
+      ) => ({
+        status: init?.status ?? 200,
+        json: async () => body,
+      }),
+    },
+  };
+});
+
+jest.mock("@/lib/db", () => ({
+  query: jest.fn(),
+  healthCheck: jest.fn(),
+}));
+
+import { query } from "@/lib/db";
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+// We need to import routes after mocks are set up
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getKpis } = require("@/app/api/city-pulse/kpis/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getTrends } = require("@/app/api/city-pulse/trends/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getCategories } = require("@/app/api/city-pulse/categories/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getHeatmap } = require("@/app/api/city-pulse/heatmap/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getNeighborhoods } = require("@/app/api/city-pulse/neighborhoods/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getNarrative } = require("@/app/api/city-pulse/narrative/route");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { NextRequest } = require("next/server");
+
+function makeRequest(url: string) {
+  return new NextRequest(url);
+}
+
+describe("City Pulse API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /api/city-pulse/kpis", () => {
+    it("returns KPI data with correct shape", async () => {
+      // sparkline query
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-12", crime_count: 10, crash_count: 5, requests_311_count: 20 },
+        { date: "2026-03-11", crime_count: 8, crash_count: 3, requests_311_count: 15 },
+      ]);
+      // totals query
+      mockQuery.mockResolvedValueOnce([
+        {
+          crime_count: 300,
+          crash_count: 100,
+          requests_311_count: 500,
+          crime_delta_pct: 5.2,
+          crash_delta_pct: -3.1,
+          requests_311_delta_pct: 12.0,
+        },
+      ]);
+
+      const res = await getKpis(makeRequest("http://localhost/api/city-pulse/kpis?timeWindow=30d"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.crime.value).toBe(300);
+      expect(body.data.crime.deltaPercent).toBe(5.2);
+      expect(body.data.crashes.value).toBe(100);
+      expect(body.data.requests311.value).toBe(500);
+      expect(body.data.crime.sparkline).toHaveLength(2);
+    });
+  });
+
+  describe("GET /api/city-pulse/trends", () => {
+    it("returns pivoted trend series", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-11", domain: "crime", count: 10 },
+        { date: "2026-03-11", domain: "crashes", count: 5 },
+        { date: "2026-03-11", domain: "311", count: 20 },
+        { date: "2026-03-12", domain: "crime", count: 12 },
+      ]);
+
+      const res = await getTrends(makeRequest("http://localhost/api/city-pulse/trends"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.series).toHaveLength(2);
+      expect(body.data.series[0]).toEqual({
+        date: "2026-03-11",
+        crime: 10,
+        crashes: 5,
+        requests311: 20,
+      });
+    });
+  });
+
+  describe("GET /api/city-pulse/categories", () => {
+    it("groups by domain", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", category: "Theft", count: 50, pct_of_total: 25.0 },
+        { domain: "311", category: "Trash", count: 30, pct_of_total: 15.0 },
+      ]);
+
+      const res = await getCategories(makeRequest("http://localhost/api/city-pulse/categories"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.crime).toHaveLength(1);
+      expect(body.data.requests311).toHaveLength(1);
+      expect(body.data.crime[0].category).toBe("Theft");
+    });
+  });
+
+  describe("GET /api/city-pulse/heatmap", () => {
+    it("returns heatmap cells", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { day_of_week: 0, hour_of_day: 12, count: 45 },
+      ]);
+
+      const res = await getHeatmap(makeRequest("http://localhost/api/city-pulse/heatmap"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data[0]).toEqual({ dayOfWeek: 0, hourOfDay: 12, count: 45 });
+    });
+  });
+
+  describe("GET /api/city-pulse/neighborhoods", () => {
+    it("returns neighborhood breakdown", async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          neighborhood: "Five Points",
+          crime_count: 80,
+          crash_count: 20,
+          requests_311_count: 100,
+          total_delta_pct: 5.5,
+        },
+      ]);
+
+      const res = await getNeighborhoods(makeRequest("http://localhost/api/city-pulse/neighborhoods"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data[0].neighborhood).toBe("Five Points");
+      expect(body.data[0].crimeCount).toBe(80);
+    });
+  });
+
+  describe("GET /api/city-pulse/narrative", () => {
+    it("assembles narrative from signals", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { signal_type: "top_domain", signal_key: "crime", signal_value: "Crime", signal_numeric: 1200 },
+        { signal_type: "top_neighborhood", signal_key: "Capitol Hill", signal_value: null, signal_numeric: 150 },
+      ]);
+
+      const res = await getNarrative(makeRequest("http://localhost/api/city-pulse/narrative"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.title).toBe("City Pulse Today");
+      expect(body.data.content).toContain("Crime");
+      expect(body.data.content).toContain("Capitol Hill");
+      expect(body.data.stats).toHaveLength(2);
+    });
+  });
+});

--- a/app/api/city-pulse/categories/route.ts
+++ b/app/api/city-pulse/categories/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCategories } from "@/lib/queries/city-pulse";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const rows = await getCategories(tw);
+
+    const grouped: Record<string, { category: string; count: number; percent: number }[]> = {
+      crime: [],
+      crashes: [],
+      requests311: [],
+    };
+
+    for (const r of rows) {
+      const key = r.domain === "311" ? "requests311" : r.domain;
+      if (key in grouped) {
+        grouped[key].push({
+          category: r.category,
+          count: r.count,
+          percent: r.pct_of_total,
+        });
+      }
+    }
+
+    return NextResponse.json({
+      data: grouped,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/city-pulse/heatmap/route.ts
+++ b/app/api/city-pulse/heatmap/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getHeatmap } from "@/lib/queries/city-pulse";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const params = request.nextUrl.searchParams;
+    const tw = (params.get("timeWindow") ?? "30d") as TimeWindow;
+    const domain = params.get("domain") ?? "all";
+
+    const rows = await getHeatmap(tw, domain);
+    const data = rows.map((r) => ({
+      dayOfWeek: r.day_of_week,
+      hourOfDay: r.hour_of_day,
+      count: r.count,
+    }));
+
+    return NextResponse.json({
+      data,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/city-pulse/kpis/route.ts
+++ b/app/api/city-pulse/kpis/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getKpiSparkline, getKpiTotals } from "@/lib/queries/city-pulse";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+const VALID_WINDOWS: TimeWindow[] = ["7d", "30d", "90d"];
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl;
+    const tw = (searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const neighborhood = searchParams.get("neighborhood") ?? "all";
+
+    if (!VALID_WINDOWS.includes(tw)) {
+      return NextResponse.json(
+        { error: "Invalid timeWindow. Use 7d, 30d, or 90d." },
+        { status: 400 }
+      );
+    }
+
+    const [sparkline, totals] = await Promise.all([
+      getKpiSparkline(tw, neighborhood),
+      getKpiTotals(tw, neighborhood),
+    ]);
+
+    const toKpi = (
+      countKey: "crime_count" | "crash_count" | "requests_311_count",
+      deltaKey: "crime_delta_pct" | "crash_delta_pct" | "requests_311_delta_pct"
+    ) => ({
+      value: totals?.[countKey] ?? 0,
+      delta: 0,
+      deltaPercent: totals?.[deltaKey] ?? 0,
+      sparkline: sparkline
+        .map((r) => ({ date: r.date, value: r[countKey] }))
+        .reverse(),
+      insight: "",
+      tag: tw,
+    });
+
+    return NextResponse.json({
+      data: {
+        crime: toKpi("crime_count", "crime_delta_pct"),
+        crashes: toKpi("crash_count", "crash_delta_pct"),
+        requests311: toKpi("requests_311_count", "requests_311_delta_pct"),
+      },
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/city-pulse/narrative/route.ts
+++ b/app/api/city-pulse/narrative/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getNarrativeSignals } from "@/lib/queries/city-pulse";
+import type { TimeWindow, NarrativeData } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+function assembleNarrative(
+  signals: { signal_type: string; signal_key: string | null; signal_value: string | null; signal_numeric: number | null }[]
+): NarrativeData {
+  const byType = new Map<string, typeof signals>();
+  for (const s of signals) {
+    if (!byType.has(s.signal_type)) byType.set(s.signal_type, []);
+    byType.get(s.signal_type)!.push(s);
+  }
+
+  const parts: string[] = [];
+  const stats: { label: string; value: string }[] = [];
+
+  const topDomain = byType.get("top_domain")?.[0];
+  if (topDomain) {
+    parts.push(
+      `${topDomain.signal_value ?? topDomain.signal_key} leads incident volume with ${topDomain.signal_numeric?.toLocaleString() ?? "N/A"} reports.`
+    );
+    stats.push({
+      label: topDomain.signal_key ?? "Top",
+      value: topDomain.signal_numeric?.toLocaleString() ?? "—",
+    });
+  }
+
+  const topNeighborhood = byType.get("top_neighborhood")?.[0];
+  if (topNeighborhood) {
+    parts.push(
+      `${topNeighborhood.signal_key} is the most active neighborhood.`
+    );
+    stats.push({
+      label: topNeighborhood.signal_key ?? "Neighborhood",
+      value: topNeighborhood.signal_numeric?.toLocaleString() ?? "—",
+    });
+  }
+
+  const topCategory = byType.get("top_category")?.[0];
+  if (topCategory) {
+    parts.push(
+      `Top category: ${topCategory.signal_key} (${topCategory.signal_value}).`
+    );
+  }
+
+  return {
+    title: "City Pulse Today",
+    content: parts.join(" ") || "No narrative data available for this period.",
+    stats,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const signals = await getNarrativeSignals(tw);
+    const data = assembleNarrative(signals);
+
+    return NextResponse.json({
+      data,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/city-pulse/neighborhoods/route.ts
+++ b/app/api/city-pulse/neighborhoods/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getNeighborhoodBreakdown } from "@/lib/queries/city-pulse";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const rows = await getNeighborhoodBreakdown(tw);
+
+    const data = rows.map((r) => ({
+      neighborhood: r.neighborhood,
+      crimeCount: r.crime_count,
+      crashCount: r.crash_count,
+      requests311Count: r.requests_311_count,
+      totalDeltaPct: r.total_delta_pct,
+    }));
+
+    return NextResponse.json({
+      data,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/city-pulse/trends/route.ts
+++ b/app/api/city-pulse/trends/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTrends } from "@/lib/queries/city-pulse";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const rows = await getTrends(tw);
+
+    // Pivot: group by date, spread domains into columns
+    const byDate = new Map<string, { crime: number; crashes: number; requests311: number }>();
+    for (const r of rows) {
+      if (!byDate.has(r.date)) {
+        byDate.set(r.date, { crime: 0, crashes: 0, requests311: 0 });
+      }
+      const entry = byDate.get(r.date)!;
+      if (r.domain === "crime") entry.crime = r.count;
+      else if (r.domain === "crashes") entry.crashes = r.count;
+      else if (r.domain === "311") entry.requests311 = r.count;
+    }
+
+    const series = Array.from(byDate.entries())
+      .map(([date, vals]) => ({ date, ...vals }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    return NextResponse.json({
+      data: { series },
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -1,0 +1,187 @@
+import { query } from "@/lib/db";
+import type { TimeWindow } from "@/lib/types";
+
+function daysForWindow(tw: TimeWindow): number {
+  return tw === "7d" ? 7 : tw === "30d" ? 30 : 90;
+}
+
+// --- KPIs ---
+
+interface DailyRow {
+  date: string;
+  crime_count: number;
+  crash_count: number;
+  requests_311_count: number;
+}
+
+interface NeighborhoodTotalRow {
+  crime_count: number;
+  crash_count: number;
+  requests_311_count: number;
+  crime_delta_pct: number | null;
+  crash_delta_pct: number | null;
+  requests_311_delta_pct: number | null;
+}
+
+export async function getKpiSparkline(
+  tw: TimeWindow,
+  neighborhood: string
+): Promise<DailyRow[]> {
+  const days = Math.min(daysForWindow(tw), 30);
+  if (neighborhood === "all") {
+    return query<DailyRow>(
+      `SELECT date::text, crime_count, crash_count, requests_311_count
+       FROM mart_city_pulse_daily
+       ORDER BY date DESC LIMIT $1`,
+      [days]
+    );
+  }
+  // When neighborhood filter is set, fall back to full daily data
+  return query<DailyRow>(
+    `SELECT date::text, crime_count, crash_count, requests_311_count
+     FROM mart_city_pulse_daily
+     ORDER BY date DESC LIMIT $1`,
+    [days]
+  );
+}
+
+export async function getKpiTotals(
+  tw: TimeWindow,
+  neighborhood: string
+): Promise<NeighborhoodTotalRow | null> {
+  if (neighborhood === "all") {
+    const rows = await query<NeighborhoodTotalRow>(
+      `SELECT SUM(crime_count)::int AS crime_count,
+              SUM(crash_count)::int AS crash_count,
+              SUM(requests_311_count)::int AS requests_311_count,
+              AVG(crime_delta_pct) AS crime_delta_pct,
+              AVG(crash_delta_pct) AS crash_delta_pct,
+              AVG(requests_311_delta_pct) AS requests_311_delta_pct
+       FROM mart_city_pulse_neighborhood
+       WHERE period = $1`,
+      [tw]
+    );
+    return rows[0] ?? null;
+  }
+  const rows = await query<NeighborhoodTotalRow>(
+    `SELECT crime_count, crash_count, requests_311_count,
+            crime_delta_pct, crash_delta_pct, requests_311_delta_pct
+     FROM mart_city_pulse_neighborhood
+     WHERE period = $1 AND neighborhood = $2`,
+    [tw, neighborhood]
+  );
+  return rows[0] ?? null;
+}
+
+// --- Trends ---
+
+interface TrendRow {
+  date: string;
+  domain: string;
+  count: number;
+}
+
+export async function getTrends(tw: TimeWindow): Promise<TrendRow[]> {
+  const days = daysForWindow(tw);
+  return query<TrendRow>(
+    `SELECT date::text, domain, SUM(count)::int AS count
+     FROM mart_incident_trends
+     WHERE date >= CURRENT_DATE - $1::int
+     GROUP BY date, domain
+     ORDER BY date`,
+    [days]
+  );
+}
+
+// --- Categories ---
+
+interface CategoryRow {
+  domain: string;
+  category: string;
+  count: number;
+  pct_of_total: number;
+}
+
+export async function getCategories(tw: TimeWindow): Promise<CategoryRow[]> {
+  return query<CategoryRow>(
+    `SELECT domain, category, count, pct_of_total
+     FROM mart_category_breakdown
+     WHERE period = $1
+     ORDER BY domain, count DESC`,
+    [tw]
+  );
+}
+
+// --- Heatmap ---
+
+interface HeatmapRow {
+  day_of_week: number;
+  hour_of_day: number;
+  count: number;
+}
+
+export async function getHeatmap(
+  tw: TimeWindow,
+  domain: string
+): Promise<HeatmapRow[]> {
+  if (domain === "all") {
+    return query<HeatmapRow>(
+      `SELECT day_of_week, hour_of_day, SUM(count)::int AS count
+       FROM mart_heatmap_hour_day
+       WHERE period = $1
+       GROUP BY day_of_week, hour_of_day
+       ORDER BY day_of_week, hour_of_day`,
+      [tw]
+    );
+  }
+  return query<HeatmapRow>(
+    `SELECT day_of_week, hour_of_day, count
+     FROM mart_heatmap_hour_day
+     WHERE period = $1 AND domain = $2
+     ORDER BY day_of_week, hour_of_day`,
+    [tw, domain]
+  );
+}
+
+// --- Neighborhoods ---
+
+interface NeighborhoodBreakdownRow {
+  neighborhood: string;
+  crime_count: number;
+  crash_count: number;
+  requests_311_count: number;
+  total_delta_pct: number | null;
+}
+
+export async function getNeighborhoodBreakdown(
+  tw: TimeWindow
+): Promise<NeighborhoodBreakdownRow[]> {
+  return query<NeighborhoodBreakdownRow>(
+    `SELECT neighborhood, crime_count, crash_count, requests_311_count, total_delta_pct
+     FROM mart_city_pulse_neighborhood
+     WHERE period = $1
+     ORDER BY (crime_count + crash_count + requests_311_count) DESC`,
+    [tw]
+  );
+}
+
+// --- Narrative ---
+
+interface NarrativeRow {
+  signal_type: string;
+  signal_key: string | null;
+  signal_value: string | null;
+  signal_numeric: number | null;
+}
+
+export async function getNarrativeSignals(
+  tw: TimeWindow
+): Promise<NarrativeRow[]> {
+  return query<NarrativeRow>(
+    `SELECT signal_type, signal_key, signal_value, signal_numeric
+     FROM mart_narrative_signals
+     WHERE period = $1
+     ORDER BY signal_type, rank`,
+    [tw]
+  );
+}


### PR DESCRIPTION
## Summary
- Add 6 City Pulse API endpoints reading from mart tables
- `GET /api/city-pulse/kpis` — KPI cards with sparkline + delta
- `GET /api/city-pulse/trends` — time series pivoted by domain
- `GET /api/city-pulse/categories` — category breakdowns
- `GET /api/city-pulse/heatmap` — hour×day heatmap
- `GET /api/city-pulse/neighborhoods` — neighborhood ranking
- `GET /api/city-pulse/narrative` — assembled narrative block
- All support `timeWindow` query param (7d/30d/90d)

Closes #34

## Test plan
- [x] 6 unit tests covering all routes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)