### PR TITLE
feat: build Environment API routes (closes #35)

### DIFF
--- a/__tests__/api-environment.test.ts
+++ b/__tests__/api-environment.test.ts
@@ -1,0 +1,107 @@
+jest.mock("next/server", () => ({
+  NextRequest: class {
+    nextUrl: URL;
+    constructor(url: string) {
+      this.nextUrl = new URL(url);
+    }
+  },
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("@/lib/db", () => ({
+  query: jest.fn(),
+}));
+
+import { query } from "@/lib/db";
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getAqi } = require("@/app/api/environment/aqi/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getRankings } = require("@/app/api/environment/rankings/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getComparison } = require("@/app/api/environment/comparison/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getNarrative } = require("@/app/api/environment/narrative/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { NextRequest } = require("next/server");
+
+function req(url: string) {
+  return new NextRequest(url);
+}
+
+describe("Environment API", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("GET /api/environment/aqi", () => {
+    it("returns current AQI and trend", async () => {
+      // current
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-13", aqi_max: 42, aqi_ozone: 38, aqi_pm25: 42, aqi_pm10: 20, category: "Good" },
+      ]);
+      // trend
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-12", aqi_max: 55, aqi_ozone: 50, aqi_pm25: 55, aqi_pm10: 30, category: "Moderate" },
+        { date: "2026-03-13", aqi_max: 42, aqi_ozone: 38, aqi_pm25: 42, aqi_pm10: 20, category: "Good" },
+      ]);
+
+      const res = await getAqi(req("http://localhost/api/environment/aqi"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.current).toEqual({ aqi: 42, category: "Good" });
+      expect(body.data.trend).toHaveLength(2);
+    });
+  });
+
+  describe("GET /api/environment/rankings", () => {
+    it("returns neighborhood rankings", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { neighborhood: "Five Points", crime_count: 80, crash_count: 20, requests_311_count: 100, composite_score: 95.5, rank: 1 },
+      ]);
+
+      const res = await getRankings(req("http://localhost/api/environment/rankings"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data[0].neighborhood).toBe("Five Points");
+      expect(body.data[0].rank).toBe(1);
+    });
+  });
+
+  describe("GET /api/environment/comparison", () => {
+    it("returns comparison with neighborhood filter", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { neighborhood: "Capitol Hill", crime_rate: 5.2, crash_rate: 1.1, requests_311_rate: 8.3, crime_delta_pct: 3.0, crash_delta_pct: -1.0, requests_311_delta_pct: 5.0 },
+      ]);
+
+      const res = await getComparison(req("http://localhost/api/environment/comparison?neighborhoods=Capitol+Hill"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data[0].neighborhood).toBe("Capitol Hill");
+      expect(body.data[0].crimeRate).toBe(5.2);
+    });
+  });
+
+  describe("GET /api/environment/narrative", () => {
+    it("assembles environment narrative", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { signal_type: "aqi_status", signal_key: "current", signal_value: "Good", signal_numeric: 42 },
+      ]);
+
+      const res = await getNarrative(req("http://localhost/api/environment/narrative"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.title).toBe("Environment Today");
+      expect(body.data.content).toContain("Good");
+      expect(body.data.stats[0].value).toBe("42");
+    });
+  });
+});

--- a/app/api/environment/aqi/route.ts
+++ b/app/api/environment/aqi/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAqiCurrent, getAqiTrend } from "@/lib/queries/environment";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+
+    const [current, trend] = await Promise.all([
+      getAqiCurrent(),
+      getAqiTrend(tw),
+    ]);
+
+    return NextResponse.json({
+      data: {
+        current: current
+          ? { aqi: current.aqi_max, category: current.category }
+          : null,
+        trend: trend.map((r) => ({
+          date: r.date,
+          aqiMax: r.aqi_max,
+          aqiOzone: r.aqi_ozone,
+          aqiPm25: r.aqi_pm25,
+          aqiPm10: r.aqi_pm10,
+          category: r.category,
+        })),
+      },
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/environment/comparison/route.ts
+++ b/app/api/environment/comparison/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getComparison } from "@/lib/queries/environment";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const params = request.nextUrl.searchParams;
+    const tw = (params.get("timeWindow") ?? "30d") as TimeWindow;
+    const nbParam = params.get("neighborhoods") ?? "";
+    const neighborhoods = nbParam ? nbParam.split(",").map((s) => s.trim()) : [];
+
+    const rows = await getComparison(tw, neighborhoods);
+
+    const data = rows.map((r) => ({
+      neighborhood: r.neighborhood,
+      crimeRate: r.crime_rate,
+      crashRate: r.crash_rate,
+      requests311Rate: r.requests_311_rate,
+      crimeDeltaPct: r.crime_delta_pct,
+      crashDeltaPct: r.crash_delta_pct,
+      requests311DeltaPct: r.requests_311_delta_pct,
+    }));
+
+    return NextResponse.json({
+      data,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/environment/narrative/route.ts
+++ b/app/api/environment/narrative/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getEnvironmentNarrativeSignals } from "@/lib/queries/environment";
+import type { TimeWindow, NarrativeData } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+function assembleNarrative(
+  signals: { signal_type: string; signal_key: string | null; signal_value: string | null; signal_numeric: number | null }[]
+): NarrativeData {
+  const parts: string[] = [];
+  const stats: { label: string; value: string }[] = [];
+
+  const aqiStatus = signals.find((s) => s.signal_type === "aqi_status");
+  if (aqiStatus) {
+    parts.push(
+      `Air quality is ${aqiStatus.signal_value ?? "unknown"} with an AQI of ${aqiStatus.signal_numeric ?? "N/A"}.`
+    );
+    stats.push({
+      label: "AQI",
+      value: String(aqiStatus.signal_numeric ?? "—"),
+    });
+  }
+
+  for (const s of signals) {
+    if (s.signal_type !== "aqi_status" && s.signal_value) {
+      parts.push(s.signal_value);
+    }
+  }
+
+  return {
+    title: "Environment Today",
+    content: parts.join(" ") || "No air quality data available for this period.",
+    stats,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const signals = await getEnvironmentNarrativeSignals(tw);
+    const data = assembleNarrative(signals);
+
+    return NextResponse.json({
+      data,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/environment/rankings/route.ts
+++ b/app/api/environment/rankings/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRankings } from "@/lib/queries/environment";
+import type { TimeWindow } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const rows = await getRankings(tw);
+
+    const data = rows.map((r) => ({
+      neighborhood: r.neighborhood,
+      crimeCount: r.crime_count,
+      crashCount: r.crash_count,
+      requests311Count: r.requests_311_count,
+      compositeScore: r.composite_score,
+      rank: r.rank,
+    }));
+
+    return NextResponse.json({
+      data,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/lib/queries/environment.ts
+++ b/lib/queries/environment.ts
@@ -1,0 +1,116 @@
+import { query } from "@/lib/db";
+import type { TimeWindow } from "@/lib/types";
+
+function daysForWindow(tw: TimeWindow): number {
+  return tw === "7d" ? 7 : tw === "30d" ? 30 : 90;
+}
+
+// --- AQI ---
+
+interface AqiRow {
+  date: string;
+  aqi_max: number | null;
+  aqi_ozone: number | null;
+  aqi_pm25: number | null;
+  aqi_pm10: number | null;
+  category: string | null;
+}
+
+export async function getAqiTrend(tw: TimeWindow): Promise<AqiRow[]> {
+  const days = daysForWindow(tw);
+  return query<AqiRow>(
+    `SELECT date::text, aqi_max, aqi_ozone, aqi_pm25, aqi_pm10, category
+     FROM mart_aqi_daily
+     WHERE date >= CURRENT_DATE - $1::int
+     ORDER BY date`,
+    [days]
+  );
+}
+
+export async function getAqiCurrent(): Promise<AqiRow | null> {
+  const rows = await query<AqiRow>(
+    `SELECT date::text, aqi_max, aqi_ozone, aqi_pm25, aqi_pm10, category
+     FROM mart_aqi_daily
+     ORDER BY date DESC LIMIT 1`
+  );
+  return rows[0] ?? null;
+}
+
+// --- Rankings ---
+
+interface RankingRow {
+  neighborhood: string;
+  crime_count: number;
+  crash_count: number;
+  requests_311_count: number;
+  composite_score: number;
+  rank: number;
+}
+
+export async function getRankings(tw: TimeWindow): Promise<RankingRow[]> {
+  return query<RankingRow>(
+    `SELECT neighborhood, crime_count, crash_count, requests_311_count,
+            composite_score, rank
+     FROM mart_neighborhood_ranking
+     WHERE period = $1
+     ORDER BY composite_score DESC`,
+    [tw]
+  );
+}
+
+// --- Comparison ---
+
+interface ComparisonRow {
+  neighborhood: string;
+  crime_rate: number | null;
+  crash_rate: number | null;
+  requests_311_rate: number | null;
+  crime_delta_pct: number | null;
+  crash_delta_pct: number | null;
+  requests_311_delta_pct: number | null;
+}
+
+export async function getComparison(
+  tw: TimeWindow,
+  neighborhoods: string[]
+): Promise<ComparisonRow[]> {
+  if (neighborhoods.length === 0) {
+    return query<ComparisonRow>(
+      `SELECT neighborhood, crime_rate, crash_rate, requests_311_rate,
+              crime_delta_pct, crash_delta_pct, requests_311_delta_pct
+       FROM mart_neighborhood_comparison
+       WHERE period = $1
+       ORDER BY neighborhood`,
+      [tw]
+    );
+  }
+  return query<ComparisonRow>(
+    `SELECT neighborhood, crime_rate, crash_rate, requests_311_rate,
+            crime_delta_pct, crash_delta_pct, requests_311_delta_pct
+     FROM mart_neighborhood_comparison
+     WHERE period = $1 AND neighborhood = ANY($2)
+     ORDER BY neighborhood`,
+    [tw, neighborhoods]
+  );
+}
+
+// --- Narrative ---
+
+interface NarrativeRow {
+  signal_type: string;
+  signal_key: string | null;
+  signal_value: string | null;
+  signal_numeric: number | null;
+}
+
+export async function getEnvironmentNarrativeSignals(
+  tw: TimeWindow
+): Promise<NarrativeRow[]> {
+  return query<NarrativeRow>(
+    `SELECT signal_type, signal_key, signal_value, signal_numeric
+     FROM mart_narrative_signals
+     WHERE period = $1 AND signal_type LIKE 'aqi%'
+     ORDER BY signal_type, rank`,
+    [tw]
+  );
+}


### PR DESCRIPTION
## Summary
- Add 4 Environment API endpoints
- `GET /api/environment/aqi` — current AQI + trend
- `GET /api/environment/rankings` — neighborhood rankings by composite score
- `GET /api/environment/comparison` — side-by-side neighborhood comparison
- `GET /api/environment/narrative` — AQI narrative block

Closes #35

## Test plan
- [x] 4 unit tests covering all routes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)