### PR TITLE
feat: build header with filter controls (closes #37)

### DIFF
--- a/__tests__/header.test.tsx
+++ b/__tests__/header.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TimeWindowFilter } from "@/components/layout/time-window-filter";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+describe("TimeWindowFilter", () => {
+  it("renders three pill buttons", () => {
+    const onChange = jest.fn();
+    render(<TimeWindowFilter value="30d" onChange={onChange} />);
+
+    expect(screen.getByText("7D")).toBeInTheDocument();
+    expect(screen.getByText("30D")).toBeInTheDocument();
+    expect(screen.getByText("90D")).toBeInTheDocument();
+  });
+
+  it("highlights active value", () => {
+    const onChange = jest.fn();
+    render(<TimeWindowFilter value="30d" onChange={onChange} />);
+
+    const active = screen.getByText("30D");
+    expect(active).toHaveClass("bg-[#102A43]");
+    expect(active).toHaveClass("text-white");
+
+    const inactive = screen.getByText("7D");
+    expect(inactive).toHaveClass("bg-[#EEF4FA]");
+  });
+
+  it("calls onChange on click", () => {
+    const onChange = jest.fn();
+    render(<TimeWindowFilter value="30d" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("7D"));
+    expect(onChange).toHaveBeenCalledWith("7d");
+  });
+});

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Suspense } from "react";
+import { MobileNav } from "./mobile-nav";
+import { TimeWindowFilter } from "./time-window-filter";
+import { NeighborhoodFilter } from "./neighborhood-filter";
+import { useFilters } from "@/lib/hooks/use-filters";
+
+interface HeaderProps {
+  title: string;
+  subtitle?: string;
+  lastUpdated?: string | null;
+}
+
+function HeaderInner({ title, subtitle, lastUpdated }: HeaderProps) {
+  const { timeWindow, neighborhood, setTimeWindow, setNeighborhood } =
+    useFilters();
+
+  return (
+    <header className="flex items-start justify-between gap-4 px-4 py-3 xl:px-5 xl:py-4">
+      <div className="flex items-center gap-3">
+        <MobileNav />
+        <div>
+          <h1 className="text-lg font-bold text-[#102A43] leading-tight">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="text-[11px] text-[#627D98] mt-0.5">{subtitle}</p>
+          )}
+          {lastUpdated && (
+            <p className="text-[10px] text-[#9FB3C8] mt-0.5">
+              Last updated: {lastUpdated}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        <TimeWindowFilter value={timeWindow} onChange={setTimeWindow} />
+        <NeighborhoodFilter value={neighborhood} onChange={setNeighborhood} />
+      </div>
+    </header>
+  );
+}
+
+export function Header(props: HeaderProps) {
+  return (
+    <Suspense
+      fallback={
+        <header className="flex items-center justify-between px-4 py-3 xl:px-5 xl:py-4">
+          <h1 className="text-lg font-bold text-[#102A43]">{props.title}</h1>
+        </header>
+      }
+    >
+      <HeaderInner {...props} />
+    </Suspense>
+  );
+}

--- a/components/layout/neighborhood-filter.tsx
+++ b/components/layout/neighborhood-filter.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface NeighborhoodFilterProps {
+  value: string;
+  onChange: (nb: string) => void;
+}
+
+export function NeighborhoodFilter({
+  value,
+  onChange,
+}: NeighborhoodFilterProps) {
+  const [neighborhoods, setNeighborhoods] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch("/api/shared/neighborhoods")
+      .then((r) => r.json())
+      .then((body) => {
+        if (body.data) {
+          setNeighborhoods(body.data.map((n: { name: string }) => n.name));
+        }
+      })
+      .catch(() => {
+        // Silently fail — dropdown will show only "All Neighborhoods"
+      });
+  }, []);
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="rounded-full bg-[#EEF4FA] border border-[#C7D5E6] px-3 py-1.5 text-xs font-medium text-[#52667A] cursor-pointer hover:bg-[#E0E8F0] appearance-none pr-7"
+      style={{
+        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2352667A' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")`,
+        backgroundRepeat: "no-repeat",
+        backgroundPosition: "right 8px center",
+      }}
+    >
+      <option value="all">All Neighborhoods</option>
+      {neighborhoods.map((name) => (
+        <option key={name} value={name}>
+          {name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/components/layout/time-window-filter.tsx
+++ b/components/layout/time-window-filter.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { TimeWindow } from "@/lib/types";
+
+const OPTIONS: { value: TimeWindow; label: string }[] = [
+  { value: "7d", label: "7D" },
+  { value: "30d", label: "30D" },
+  { value: "90d", label: "90D" },
+];
+
+interface TimeWindowFilterProps {
+  value: TimeWindow;
+  onChange: (tw: TimeWindow) => void;
+}
+
+export function TimeWindowFilter({ value, onChange }: TimeWindowFilterProps) {
+  return (
+    <div className="flex gap-1">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
+            value === opt.value
+              ? "bg-[#102A43] text-white"
+              : "bg-[#EEF4FA] text-[#52667A] border border-[#C7D5E6] hover:bg-[#E0E8F0]"
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/lib/hooks/use-filters.ts
+++ b/lib/hooks/use-filters.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useCallback } from "react";
+import type { TimeWindow } from "@/lib/types";
+
+export function useFilters() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const timeWindow = (searchParams.get("tw") ?? "30d") as TimeWindow;
+  const neighborhood = searchParams.get("nb") ?? "all";
+
+  const setFilter = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === "30d" && key === "tw") {
+        params.delete(key);
+      } else if (value === "all" && key === "nb") {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+      const qs = params.toString();
+      router.push(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [searchParams, router, pathname]
+  );
+
+  const setTimeWindow = useCallback(
+    (tw: TimeWindow) => setFilter("tw", tw),
+    [setFilter]
+  );
+
+  const setNeighborhood = useCallback(
+    (nb: string) => setFilter("nb", nb),
+    [setFilter]
+  );
+
+  return { timeWindow, neighborhood, setTimeWindow, setNeighborhood };
+}


### PR DESCRIPTION
## Summary
- Add `Header` component with dynamic title, filters, and last-updated indicator
- Add `TimeWindowFilter` — 3 pill buttons (7D/30D/90D) per design brief
- Add `NeighborhoodFilter` — dropdown populated from `/api/shared/neighborhoods`
- Add `useFilters` hook — reads/writes URL search params for shareable filter state

Closes #37

## Test plan
- [x] 3 unit tests for TimeWindowFilter (render, active state, click handler)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)