### PR TITLE
feat: build reusable card components (closes #38)

### DIFF
--- a/__tests__/cards.test.tsx
+++ b/__tests__/cards.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { KpiCard } from "@/components/cards/kpi-card";
+import { ChartCard } from "@/components/cards/chart-card";
+import { NarrativeBlock } from "@/components/cards/narrative-block";
+
+// Mock recharts to avoid canvas issues in jsdom
+jest.mock("recharts", () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("KpiCard", () => {
+  it("renders with value and title", () => {
+    render(
+      <KpiCard
+        title="Crime"
+        value={1234}
+        color="#2458C6"
+        deltaPercent={5.2}
+      />
+    );
+    expect(screen.getByText("Crime")).toBeInTheDocument();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.getByText("+5.2%")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton", () => {
+    const { container } = render(
+      <KpiCard title="Crime" value={0} color="#2458C6" loading={true} />
+    );
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
+describe("ChartCard", () => {
+  it("renders title and children", () => {
+    render(
+      <ChartCard title="Incident Trends">
+        <div data-testid="chart-content">Chart here</div>
+      </ChartCard>
+    );
+    expect(screen.getByText("Incident Trends")).toBeInTheDocument();
+    expect(screen.getByTestId("chart-content")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton", () => {
+    const { container } = render(
+      <ChartCard title="Trends" loading={true}>
+        <div />
+      </ChartCard>
+    );
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
+describe("NarrativeBlock", () => {
+  it("renders dark panel with content and stats", () => {
+    render(
+      <NarrativeBlock
+        title="City Pulse Today"
+        content="Crime leads incident volume."
+        stats={[{ label: "crime", value: "1,200" }]}
+      />
+    );
+    expect(screen.getByText("City Pulse Today")).toBeInTheDocument();
+    expect(screen.getByText("Crime leads incident volume.")).toBeInTheDocument();
+    expect(screen.getByText("1,200")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton", () => {
+    const { container } = render(
+      <NarrativeBlock title="" content="" loading={true} />
+    );
+    // Dark bg skeletons use bg-white/10
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/components/cards/chart-card.tsx
+++ b/components/cards/chart-card.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface ChartCardProps {
+  title: string;
+  children: React.ReactNode;
+  insight?: string;
+  loading?: boolean;
+}
+
+export function ChartCard({ title, children, insight, loading }: ChartCardProps) {
+  if (loading) {
+    return (
+      <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+        <Skeleton className="h-3.5 w-32 mb-3" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-2.5 w-2/3 mt-3" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+      <h3 className="text-xs font-bold text-[#102A43] mb-2">{title}</h3>
+      <div className="bg-[#F8FAFC] rounded-lg p-2">{children}</div>
+      {insight && (
+        <p className="text-[10px] text-[#6B7B8D] mt-2 leading-tight">
+          {insight}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/cards/kpi-card.tsx
+++ b/components/cards/kpi-card.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { DeltaBadge } from "@/components/ui/delta-badge";
+import { Sparkline } from "@/components/ui/sparkline";
+import { formatNumber } from "@/lib/format";
+import type { ChartPoint } from "@/lib/types";
+
+interface KpiCardProps {
+  title: string;
+  tag?: string;
+  secondaryTag?: string;
+  value: number;
+  delta?: number;
+  deltaPercent?: number;
+  sparklineData?: ChartPoint[];
+  insight?: string;
+  color: string;
+  loading?: boolean;
+}
+
+export function KpiCard({
+  title,
+  tag,
+  secondaryTag,
+  value,
+  deltaPercent,
+  sparklineData = [],
+  insight,
+  color,
+  loading,
+}: KpiCardProps) {
+  if (loading) {
+    return (
+      <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+        <div className="flex items-center justify-between mb-2">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-3 w-10" />
+        </div>
+        <Skeleton className="h-8 w-24 mb-2" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-7 w-20" />
+        </div>
+        <Skeleton className="h-2.5 w-full mt-2" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[11px] font-bold text-[#52667A] uppercase tracking-wide">
+          {title}
+        </span>
+        {(tag || secondaryTag) && (
+          <span className="text-[10px] text-[#627D98]">
+            {secondaryTag ?? tag}
+          </span>
+        )}
+      </div>
+
+      <div className="text-[34px] font-bold text-[#102A43] leading-none mb-1">
+        {formatNumber(value)}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <DeltaBadge value={deltaPercent} />
+        <Sparkline data={sparklineData} color={color} />
+      </div>
+
+      {insight && (
+        <p className="text-[10px] text-[#627D98] mt-2 leading-tight line-clamp-1">
+          {insight}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/cards/narrative-block.tsx
+++ b/components/cards/narrative-block.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface NarrativeBlockProps {
+  title: string;
+  content: string;
+  stats?: { label: string; value: string }[];
+  loading?: boolean;
+}
+
+export function NarrativeBlock({
+  title,
+  content,
+  stats = [],
+  loading,
+}: NarrativeBlockProps) {
+  if (loading) {
+    return (
+      <div className="rounded-[14px] bg-[#163A5D] p-4 shadow-[0_4px_12px_#102A4320]">
+        <Skeleton className="h-4 w-40 mb-3 bg-white/10" />
+        <Skeleton className="h-3 w-full mb-1 bg-white/10" />
+        <Skeleton className="h-3 w-4/5 mb-1 bg-white/10" />
+        <Skeleton className="h-3 w-3/5 mb-4 bg-white/10" />
+        <div className="flex gap-2">
+          <Skeleton className="h-6 w-20 rounded-full bg-white/10" />
+          <Skeleton className="h-6 w-20 rounded-full bg-white/10" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[14px] bg-[#163A5D] p-4 shadow-[0_4px_12px_#102A4320]">
+      <h3 className="text-sm font-bold text-white mb-2">{title}</h3>
+      <p className="text-[11px] text-[#D7E5F5] leading-[1.45] mb-3">
+        {content}
+      </p>
+      {stats.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {stats.map((stat) => (
+            <span
+              key={stat.label}
+              className="inline-flex items-center gap-1 rounded-full bg-white/8 px-2.5 py-1 text-[10px] text-white/90"
+            >
+              <span className="font-semibold">{stat.value}</span>
+              <span className="text-white/60">{stat.label}</span>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/delta-badge.tsx
+++ b/components/ui/delta-badge.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+import { formatDelta } from "@/lib/format";
+import { TrendingUp, TrendingDown } from "lucide-react";
+
+interface DeltaBadgeProps {
+  value: number | null | undefined;
+  className?: string;
+}
+
+export function DeltaBadge({ value, className }: DeltaBadgeProps) {
+  if (value == null) return null;
+
+  const isPositive = value > 0;
+  const isNegative = value < 0;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
+        isPositive && "bg-[#198754]/10 text-[#198754]",
+        isNegative && "bg-[#DC3545]/10 text-[#DC3545]",
+        !isPositive && !isNegative && "bg-[#EEF3F8] text-[#627D98]",
+        className
+      )}
+    >
+      {isPositive && <TrendingUp size={10} />}
+      {isNegative && <TrendingDown size={10} />}
+      {formatDelta(value)}
+    </span>
+  );
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+export function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-[#EEF3F8]", className)}
+      {...props}
+    />
+  );
+}

--- a/components/ui/sparkline.tsx
+++ b/components/ui/sparkline.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { AreaChart, Area, ResponsiveContainer } from "recharts";
+import type { ChartPoint } from "@/lib/types";
+
+interface SparklineProps {
+  data: ChartPoint[];
+  color: string;
+  width?: number;
+  height?: number;
+}
+
+export function Sparkline({
+  data,
+  color,
+  width = 80,
+  height = 28,
+}: SparklineProps) {
+  if (data.length === 0) return null;
+
+  return (
+    <div style={{ width, height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+          <defs>
+            <linearGradient id={`spark-${color}`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={color} stopOpacity={0.05} />
+            </linearGradient>
+          </defs>
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke={color}
+            strokeWidth={1.5}
+            fill={`url(#spark-${color})`}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `KpiCard` — large number, delta badge, sparkline, insight text
- Add `ChartCard` — wrapper for any chart with title and insight footer
- Add `NarrativeBlock` — dark panel with stat badges
- Add primitives: `Skeleton`, `DeltaBadge`, `Sparkline` (Recharts AreaChart)
- All 3 cards support `loading` prop with skeleton states

Closes #38

## Test plan
- [x] 6 unit tests (render + loading for each card type)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)