### PR TITLE
feat: build app layout and responsive grid (closes #39)

### DIFF
--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -1,11 +1,43 @@
 import { render, screen } from "@testing-library/react";
 import CityPulsePage from "@/app/page";
 
+// Mock next/navigation for Header component
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// Mock fetch for NeighborhoodFilter
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ data: [] }) })
+) as jest.Mock;
+
+// Mock recharts
+jest.mock("recharts", () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Area: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
 describe("CityPulsePage", () => {
   it("renders the page heading", () => {
     render(<CityPulsePage />);
     expect(
-      screen.getByRole("heading", { name: /denver urban pulse/i })
+      screen.getByRole("heading", { name: /city pulse/i })
     ).toBeInTheDocument();
+  });
+
+  it("renders KPI cards in loading state", () => {
+    const { container } = render(<CityPulsePage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders grid structure with expected sections", () => {
+    const { container } = render(<CityPulsePage />);
+    // 3 grid sections: KPI row, hero row, analytics row
+    const grids = container.querySelectorAll(".grid");
+    expect(grids.length).toBe(3);
   });
 });

--- a/app/environment/page.tsx
+++ b/app/environment/page.tsx
@@ -1,10 +1,64 @@
+import { PageShell } from "@/components/layout/page-shell";
+import { KpiCard } from "@/components/cards/kpi-card";
+import { ChartCard } from "@/components/cards/chart-card";
+import { NarrativeBlock } from "@/components/cards/narrative-block";
+
 export default function EnvironmentPage() {
   return (
-    <main className="min-h-screen bg-bg-page p-5">
-      <h1 className="text-2xl font-bold text-text-primary">
-        Environment &amp; Neighborhoods
-      </h1>
-      <p className="mt-2 text-text-secondary">Coming soon.</p>
-    </main>
+    <PageShell
+      title="Environment & Neighborhoods"
+      subtitle="Air quality and neighborhood analytics"
+    >
+      {/* KPI Row */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <KpiCard
+          title="Air Quality Index"
+          tag="Current"
+          value={0}
+          color="#0B4F8C"
+          loading
+        />
+        <KpiCard
+          title="Safest Neighborhood"
+          tag="30D"
+          value={0}
+          color="#198754"
+          loading
+        />
+        <KpiCard
+          title="Most Active Area"
+          tag="30D"
+          value={0}
+          color="#D97904"
+          loading
+        />
+      </div>
+
+      {/* Hero Row — 60/40 split */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3">
+        <div className="lg:col-span-3">
+          <ChartCard title="AQI Trend" loading>
+            <div className="h-48" />
+          </ChartCard>
+        </div>
+        <div className="lg:col-span-2">
+          <NarrativeBlock
+            title="Environment Today"
+            content=""
+            loading
+          />
+        </div>
+      </div>
+
+      {/* Lower Analytics — 2×2 grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <ChartCard title="Neighborhood Rankings" loading>
+          <div className="h-48" />
+        </ChartCard>
+        <ChartCard title="Neighborhood Comparison" loading>
+          <div className="h-48" />
+        </ChartCard>
+      </div>
+    </PageShell>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Sans } from "next/font/google";
+import { Sidebar } from "@/components/layout/sidebar";
 import "./globals.css";
 
 const ibmPlexSans = IBM_Plex_Sans({
@@ -22,7 +23,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${ibmPlexSans.variable} antialiased`}>{children}</body>
+      <body className={`${ibmPlexSans.variable} antialiased`}>
+        <div className="flex min-h-screen">
+          <Sidebar />
+          {children}
+        </div>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,73 @@
+import { PageShell } from "@/components/layout/page-shell";
+import { KpiCard } from "@/components/cards/kpi-card";
+import { ChartCard } from "@/components/cards/chart-card";
+import { NarrativeBlock } from "@/components/cards/narrative-block";
+
 export default function CityPulsePage() {
   return (
-    <main className="min-h-screen bg-bg-page p-5">
-      <h1 className="text-2xl font-bold text-text-primary">
-        Denver Urban Pulse
-      </h1>
-      <p className="mt-2 text-text-secondary">
-        City Intelligence Overview — coming soon.
-      </p>
-    </main>
+    <PageShell
+      title="City Pulse"
+      subtitle="Crime, crashes, and 311 requests across Denver"
+    >
+      {/* KPI Row */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <KpiCard
+          title="Crime Incidents"
+          tag="30D"
+          value={0}
+          deltaPercent={0}
+          color="#2458C6"
+          loading
+        />
+        <KpiCard
+          title="Traffic Crashes"
+          tag="30D"
+          value={0}
+          deltaPercent={0}
+          color="#D97904"
+          loading
+        />
+        <KpiCard
+          title="311 Requests"
+          tag="30D"
+          value={0}
+          deltaPercent={0}
+          color="#198754"
+          loading
+        />
+      </div>
+
+      {/* Hero Row — 60/40 split */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3">
+        <div className="lg:col-span-3">
+          <ChartCard title="Incident Trends" loading>
+            <div className="h-48" />
+          </ChartCard>
+        </div>
+        <div className="lg:col-span-2">
+          <NarrativeBlock
+            title="City Pulse Today"
+            content=""
+            loading
+          />
+        </div>
+      </div>
+
+      {/* Lower Analytics — 2×2 grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <ChartCard title="Category Breakdown" loading>
+          <div className="h-48" />
+        </ChartCard>
+        <ChartCard title="Time Heatmap" loading>
+          <div className="h-48" />
+        </ChartCard>
+        <ChartCard title="Neighborhood Map" loading>
+          <div className="h-48" />
+        </ChartCard>
+        <ChartCard title="Top Neighborhoods" loading>
+          <div className="h-48" />
+        </ChartCard>
+      </div>
+    </PageShell>
   );
 }

--- a/components/layout/page-shell.tsx
+++ b/components/layout/page-shell.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Header } from "./header";
+
+interface PageShellProps {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}
+
+export function PageShell({ title, subtitle, children }: PageShellProps) {
+  return (
+    <div className="flex-1 min-h-screen bg-[#F4F6F8] overflow-auto">
+      <Header title={title} subtitle={subtitle} />
+      <div className="px-4 pb-6 xl:px-5 space-y-4">{children}</div>
+    </div>
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -8,7 +8,7 @@ const pool = new Pool({
   connectionTimeoutMillis: 5_000,
 });
 
-export async function query<T extends Record<string, unknown>>(
+export async function query<T extends object>(
   text: string,
   params?: unknown[]
 ): Promise<T[]> {


### PR DESCRIPTION
## Summary
- Update root `layout.tsx` — add Sidebar alongside main content
- Add `PageShell` component — shared wrapper with Header + content area
- Update City Pulse page with grid layout: KPI row (3 cards), hero row (60/40), analytics (2×2)
- Update Environment page with matching grid layout
- All cards render in loading state (skeletons) — Phase 4/5 will connect real data
- Fix `query<T>` generic constraint to support interfaces
- Responsive: desktop (sidebar visible, multi-col), tablet (2-col), mobile (single-col stack)

Closes #39

## Test plan
- [x] Build passes with all routes
- [x] 3 page tests: heading renders, skeleton states, grid structure
- [x] 51/53 tests pass (2 pre-existing db.test.ts failures)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)