### PR TITLE
test: add tests for Environment page and components

### DIFF
--- a/__tests__/charts-environment.test.tsx
+++ b/__tests__/charts-environment.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { AqiTrendChart } from "@/components/charts/aqi-trend-chart";
+import { NeighborhoodComparisonChart } from "@/components/charts/neighborhood-comparison-chart";
+import { ChangeLeadersChart } from "@/components/charts/change-leaders-chart";
+import type { AqiDailyPoint, ComparisonRow } from "@/lib/types";
+
+// Mock recharts to avoid canvas issues in jsdom
+jest.mock("recharts", () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  ),
+  Area: () => <div />,
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  Legend: () => <div />,
+  Cell: () => <div />,
+  ReferenceArea: () => <div />,
+  ReferenceLine: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const sampleAqi: AqiDailyPoint[] = [
+  { date: "2026-03-01", aqiMax: 42, aqiOzone: 38, aqiPm25: 42, aqiPm10: 15, category: "Good" },
+  { date: "2026-03-02", aqiMax: 65, aqiOzone: 50, aqiPm25: 65, aqiPm10: 20, category: "Moderate" },
+  { date: "2026-03-03", aqiMax: 110, aqiOzone: 80, aqiPm25: 110, aqiPm10: 30, category: "USG" },
+];
+
+describe("AqiTrendChart", () => {
+  it("renders with sample data", () => {
+    const { container } = render(<AqiTrendChart data={sampleAqi} />);
+    expect(container.querySelector("[data-testid='area-chart']")).toBeInTheDocument();
+  });
+
+  it("shows empty message for no data", () => {
+    render(<AqiTrendChart data={[]} />);
+    expect(screen.getByText("No AQI data available")).toBeInTheDocument();
+  });
+});
+
+const sampleComparison: ComparisonRow[] = [
+  { neighborhood: "Five Points", crimeRate: 12.5, crashRate: 3.2, requests311Rate: 8.1, crimeDeltaPct: 5.0, crashDeltaPct: -2.0, requests311DeltaPct: 1.0 },
+  { neighborhood: "Capitol Hill", crimeRate: 10.0, crashRate: 4.5, requests311Rate: 6.0, crimeDeltaPct: -3.0, crashDeltaPct: -1.0, requests311DeltaPct: -2.0 },
+  { neighborhood: "CBD", crimeRate: 15.0, crashRate: 5.0, requests311Rate: 10.0, crimeDeltaPct: 8.0, crashDeltaPct: 3.0, requests311DeltaPct: 5.0 },
+  { neighborhood: "Baker", crimeRate: 8.0, crashRate: 2.0, requests311Rate: 5.0, crimeDeltaPct: -5.0, crashDeltaPct: -4.0, requests311DeltaPct: -6.0 },
+  { neighborhood: "RiNo", crimeRate: 11.0, crashRate: 3.5, requests311Rate: 7.0, crimeDeltaPct: 2.0, crashDeltaPct: 1.0, requests311DeltaPct: 3.0 },
+  { neighborhood: "Highlands", crimeRate: 7.0, crashRate: 2.5, requests311Rate: 4.0, crimeDeltaPct: -1.0, crashDeltaPct: -2.5, requests311DeltaPct: -1.5 },
+  { neighborhood: "LoDo", crimeRate: 14.0, crashRate: 6.0, requests311Rate: 9.0, crimeDeltaPct: 10.0, crashDeltaPct: 4.0, requests311DeltaPct: 7.0 },
+  { neighborhood: "Montbello", crimeRate: 9.0, crashRate: 3.0, requests311Rate: 6.5, crimeDeltaPct: -6.0, crashDeltaPct: -3.0, requests311DeltaPct: -4.0 },
+  { neighborhood: "Cherry Creek", crimeRate: 6.0, crashRate: 1.5, requests311Rate: 3.0, crimeDeltaPct: 0.5, crashDeltaPct: 0.0, requests311DeltaPct: 0.5 },
+  { neighborhood: "Stapleton", crimeRate: 5.0, crashRate: 1.0, requests311Rate: 2.5, crimeDeltaPct: -0.5, crashDeltaPct: -0.5, requests311DeltaPct: -1.0 },
+];
+
+describe("NeighborhoodComparisonChart", () => {
+  it("renders with sample data", () => {
+    const { container } = render(<NeighborhoodComparisonChart data={sampleComparison} />);
+    expect(container.querySelector("[data-testid='bar-chart']")).toBeInTheDocument();
+  });
+
+  it("shows empty message for no data", () => {
+    render(<NeighborhoodComparisonChart data={[]} />);
+    expect(screen.getByText("No comparison data available")).toBeInTheDocument();
+  });
+});
+
+describe("ChangeLeadersChart", () => {
+  it("renders with sample data", () => {
+    const { container } = render(<ChangeLeadersChart data={sampleComparison} />);
+    expect(container.querySelector("[data-testid='bar-chart']")).toBeInTheDocument();
+  });
+
+  it("shows empty message for no data", () => {
+    render(<ChangeLeadersChart data={[]} />);
+    expect(screen.getByText("No change data available")).toBeInTheDocument();
+  });
+});

--- a/__tests__/page-environment.test.tsx
+++ b/__tests__/page-environment.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+
+// Mock global fetch
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ data: [] }),
+  })
+) as jest.Mock;
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/environment",
+}));
+
+// Mock recharts
+jest.mock("recharts", () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  ),
+  Area: () => <div />,
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  Legend: () => <div />,
+  Cell: () => <div />,
+  ReferenceArea: () => <div />,
+  ReferenceLine: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+// Mock react-leaflet
+jest.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div />,
+  GeoJSON: () => <div />,
+}));
+jest.mock("leaflet/dist/leaflet.css", () => ({}));
+
+// Mock GeoJSON import
+jest.mock("@/data/geo/denver-neighborhoods.json", () => ({
+  type: "FeatureCollection",
+  features: [],
+}));
+
+import EnvironmentPage from "@/app/environment/page";
+import { useEnvironmentData } from "@/lib/hooks/use-environment-data";
+
+jest.mock("@/lib/hooks/use-environment-data");
+const mockUseEnvironmentData = useEnvironmentData as jest.MockedFunction<typeof useEnvironmentData>;
+
+describe("EnvironmentPage", () => {
+  it("renders loading state", () => {
+    mockUseEnvironmentData.mockReturnValue({
+      aqi: { current: null, trend: [] },
+      rankings: [],
+      comparison: [],
+      narrative: null,
+      loading: true,
+      error: null,
+    });
+
+    const { container } = render(<EnvironmentPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders with data", () => {
+    mockUseEnvironmentData.mockReturnValue({
+      aqi: {
+        current: { aqi: 42, category: "Good" },
+        trend: [{ date: "2026-03-01", aqiMax: 42, aqiOzone: 38, aqiPm25: 42, aqiPm10: 15, category: "Good" }],
+      },
+      rankings: [
+        { neighborhood: "Highlands", crimeCount: 50, crashCount: 10, requests311Count: 30, compositeScore: 15.2, rank: 1 },
+        { neighborhood: "CBD", crimeCount: 200, crashCount: 60, requests311Count: 120, compositeScore: 85.5, rank: 78 },
+      ],
+      comparison: [
+        { neighborhood: "Highlands", crimeRate: 5.0, crashRate: 1.5, requests311Rate: 3.0, crimeDeltaPct: -3.0, crashDeltaPct: -2.0, requests311DeltaPct: -1.0 },
+      ],
+      narrative: { title: "Environment Today", content: "Air quality is good.", stats: [{ label: "AQI", value: "42" }] },
+      loading: false,
+      error: null,
+    });
+
+    render(<EnvironmentPage />);
+    expect(screen.getByText("Environment & Neighborhoods")).toBeInTheDocument();
+    expect(screen.getByText("Air quality is good.")).toBeInTheDocument();
+    expect(screen.getAllByText("42").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders error state", () => {
+    mockUseEnvironmentData.mockReturnValue({
+      aqi: { current: null, trend: [] },
+      rankings: [],
+      comparison: [],
+      narrative: null,
+      loading: false,
+      error: "Connection refused",
+    });
+
+    render(<EnvironmentPage />);
+    expect(screen.getByText("Failed to load data")).toBeInTheDocument();
+    expect(screen.getByText("Connection refused")).toBeInTheDocument();
+  });
+});
+
+describe("useEnvironmentData hook", () => {
+  it("returns correct initial structure", () => {
+    mockUseEnvironmentData.mockReturnValue({
+      aqi: { current: null, trend: [] },
+      rankings: [],
+      comparison: [],
+      narrative: null,
+      loading: true,
+      error: null,
+    });
+
+    const result = mockUseEnvironmentData("30d", "all");
+    expect(result.loading).toBe(true);
+    expect(result.aqi.current).toBeNull();
+    expect(result.rankings).toEqual([]);
+    expect(result.comparison).toEqual([]);
+    expect(result.narrative).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- 10 new tests across 2 test files
- `charts-environment.test.tsx`: render + empty state tests for AqiTrendChart, NeighborhoodComparisonChart, ChangeLeadersChart
- `page-environment.test.tsx`: loading state, data render, error state, hook structure tests
- All 76 tests pass (was 66, +10 new)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)