### PR TITLE
Fix pipeline mart SQL errors

### DIFF
--- a/data/marts/build_aqi_daily.py
+++ b/data/marts/build_aqi_daily.py
@@ -16,21 +16,29 @@ logger = logging.getLogger(__name__)
 BUILD_SQL = """
 INSERT INTO mart_aqi_daily (date, aqi_ozone, aqi_pm25, aqi_pm10, aqi_max, category, updated_at)
 SELECT
-    (observed_at AT TIME ZONE 'America/Denver')::date AS date,
-    MAX(CASE WHEN parameter_name = 'OZONE' THEN aqi END) AS aqi_ozone,
-    MAX(CASE WHEN parameter_name = 'PM2.5' THEN aqi END) AS aqi_pm25,
-    MAX(CASE WHEN parameter_name = 'PM10' THEN aqi END) AS aqi_pm10,
-    MAX(aqi) AS aqi_max,
-    -- Category from the parameter with the highest AQI
+    d.date,
+    d.aqi_ozone,
+    d.aqi_pm25,
+    d.aqi_pm10,
+    d.aqi_max,
+    -- Category from the row with the highest AQI on that date
     (
         SELECT sq.category FROM stg_aqi sq
-        WHERE (sq.observed_at AT TIME ZONE 'America/Denver')::date = (s.observed_at AT TIME ZONE 'America/Denver')::date
+        WHERE (sq.observed_at AT TIME ZONE 'America/Denver')::date = d.date
         ORDER BY sq.aqi DESC
         LIMIT 1
     ) AS category,
     NOW()
-FROM stg_aqi s
-GROUP BY (observed_at AT TIME ZONE 'America/Denver')::date
+FROM (
+    SELECT
+        (observed_at AT TIME ZONE 'America/Denver')::date AS date,
+        MAX(CASE WHEN parameter_name = 'OZONE' THEN aqi END) AS aqi_ozone,
+        MAX(CASE WHEN parameter_name = 'PM2.5' THEN aqi END) AS aqi_pm25,
+        MAX(CASE WHEN parameter_name = 'PM10' THEN aqi END) AS aqi_pm10,
+        MAX(aqi) AS aqi_max
+    FROM stg_aqi
+    GROUP BY (observed_at AT TIME ZONE 'America/Denver')::date
+) d
 ON CONFLICT (date) DO UPDATE SET
     aqi_ozone = EXCLUDED.aqi_ozone,
     aqi_pm25 = EXCLUDED.aqi_pm25,

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -34,13 +34,13 @@ SELECT
          THEN ROUND((COALESCE(cur.r311, 0)::numeric / n.shape_area) * 1000000, 4)
          ELSE 0 END,
     CASE WHEN COALESCE(prev.crime, 0) > 0
-         THEN ROUND(((COALESCE(cur.crime, 0) - prev.crime)::numeric / prev.crime) * 100, 1)
+         THEN ROUND(((COALESCE(cur.crime, 0) - prev.crime)::numeric / prev.crime * 100)::numeric, 1)
          ELSE NULL END,
     CASE WHEN COALESCE(prev.crashes, 0) > 0
-         THEN ROUND(((COALESCE(cur.crashes, 0) - prev.crashes)::numeric / prev.crashes) * 100, 1)
+         THEN ROUND(((COALESCE(cur.crashes, 0) - prev.crashes)::numeric / prev.crashes * 100)::numeric, 1)
          ELSE NULL END,
     CASE WHEN COALESCE(prev.r311, 0) > 0
-         THEN ROUND(((COALESCE(cur.r311, 0) - prev.r311)::numeric / prev.r311) * 100, 1)
+         THEN ROUND(((COALESCE(cur.r311, 0) - prev.r311)::numeric / prev.r311 * 100)::numeric, 1)
          ELSE NULL END,
     NOW()
 FROM stg_neighborhoods n


### PR DESCRIPTION
## Summary
- **mart_aqi_daily**: Fixed correlated subquery that referenced ungrouped column `s.observed_at`. Wrapped GROUP BY in a derived table `d` so the subquery references `d.date`.
- **mart_neighborhood_comparison**: Added `::numeric` cast to all three `ROUND()` calls for delta_pct calculations. PostgreSQL's `ROUND(x, n)` requires numeric, not double precision.

## Test plan
- [ ] Re-run pipeline: all 7 marts build successfully
- [ ] Dashboard displays data for all sections

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)