### PR TITLE
Fix remaining ROUND cast in neighborhood comparison rates

### DIFF
--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -25,13 +25,13 @@ SELECT
     %(period)s AS period,
     n.nbhd_name AS neighborhood,
     CASE WHEN n.shape_area > 0
-         THEN ROUND((COALESCE(cur.crime, 0)::numeric / n.shape_area) * 1000000, 4)
+         THEN ROUND((COALESCE(cur.crime, 0)::numeric / n.shape_area::numeric * 1000000)::numeric, 4)
          ELSE 0 END,
     CASE WHEN n.shape_area > 0
-         THEN ROUND((COALESCE(cur.crashes, 0)::numeric / n.shape_area) * 1000000, 4)
+         THEN ROUND((COALESCE(cur.crashes, 0)::numeric / n.shape_area::numeric * 1000000)::numeric, 4)
          ELSE 0 END,
     CASE WHEN n.shape_area > 0
-         THEN ROUND((COALESCE(cur.r311, 0)::numeric / n.shape_area) * 1000000, 4)
+         THEN ROUND((COALESCE(cur.r311, 0)::numeric / n.shape_area::numeric * 1000000)::numeric, 4)
          ELSE 0 END,
     CASE WHEN COALESCE(prev.crime, 0) > 0
          THEN ROUND(((COALESCE(cur.crime, 0) - prev.crime)::numeric / prev.crime * 100)::numeric, 1)


### PR DESCRIPTION
## Summary
- Added `::numeric` cast to the three rate calculations (`crime_rate`, `crash_rate`, `requests_311_rate`) in `build_neighborhood_comparison.py`
- `shape_area` is `double precision`; dividing `numeric / double` yields `double`, which PostgreSQL's `ROUND(x, n)` rejects
- Previous fix (#94) only addressed the delta calculations, this completes the fix for rate calculations

## Test plan
- [x] Ran mart locally — 234 rows across 3 periods, no errors
- [ ] Full pipeline re-run succeeds with all 7 marts OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)