### PR TITLE
Fix: add Denver timezone conversion to mart date operations

### DIFF
--- a/data/marts/build_category_breakdown.py
+++ b/data/marts/build_category_breakdown.py
@@ -24,7 +24,7 @@ SELECT
     COALESCE(offense_category, 'Unknown'),
     COUNT(*), 0, NOW()
 FROM stg_crime
-WHERE reported_date >= CURRENT_DATE - %(days)s
+WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
 GROUP BY offense_category
 
 UNION ALL
@@ -35,7 +35,7 @@ SELECT
     COALESCE(top_offense, 'Unknown'),
     COUNT(*), 0, NOW()
 FROM stg_crashes
-WHERE reported_date >= CURRENT_DATE - %(days)s
+WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
 GROUP BY top_offense
 
 UNION ALL
@@ -46,7 +46,7 @@ SELECT
     COALESCE(request_type, 'Unknown'),
     COUNT(*), 0, NOW()
 FROM stg_311
-WHERE case_created_date >= CURRENT_DATE - %(days)s
+WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
 GROUP BY request_type
 
 ON CONFLICT (period, domain, category) DO UPDATE SET

--- a/data/marts/build_city_pulse_daily.py
+++ b/data/marts/build_city_pulse_daily.py
@@ -27,32 +27,32 @@ SELECT
     COALESCE(ca.fatalities, 0),
     NOW()
 FROM (
-    SELECT reported_date::date AS date FROM stg_crime
+    SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date FROM stg_crime
     UNION
-    SELECT reported_date::date AS date FROM stg_crashes
+    SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date FROM stg_crashes
     UNION
-    SELECT case_created_date::date AS date FROM stg_311
+    SELECT (case_created_date AT TIME ZONE 'America/Denver')::date AS date FROM stg_311
 ) d
 LEFT JOIN (
-    SELECT reported_date::date AS date,
+    SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date,
            COUNT(*) AS crime_count,
            SUM(victim_count) AS victim_count
     FROM stg_crime
-    GROUP BY reported_date::date
+    GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date
 ) cr ON cr.date = d.date
 LEFT JOIN (
-    SELECT reported_date::date AS date,
+    SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date,
            COUNT(*) AS crash_count,
            SUM(seriously_injured) AS serious_injuries,
            SUM(fatalities) AS fatalities
     FROM stg_crashes
-    GROUP BY reported_date::date
+    GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date
 ) ca ON ca.date = d.date
 LEFT JOIN (
-    SELECT case_created_date::date AS date,
+    SELECT (case_created_date AT TIME ZONE 'America/Denver')::date AS date,
            COUNT(*) AS requests_count
     FROM stg_311
-    GROUP BY case_created_date::date
+    GROUP BY (case_created_date AT TIME ZONE 'America/Denver')::date
 ) r ON r.date = d.date
 ON CONFLICT (date) DO UPDATE SET
     crime_count = EXCLUDED.crime_count,

--- a/data/marts/build_city_pulse_neighborhood.py
+++ b/data/marts/build_city_pulse_neighborhood.py
@@ -57,13 +57,13 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
 ) cur ON cur.neighborhood = n.neighborhood
@@ -75,18 +75,18 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
-          AND reported_date < CURRENT_DATE - %(days)s
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
+          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
-          AND reported_date < CURRENT_DATE - %(days)s
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
+          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= CURRENT_DATE - %(days)s * 2
-          AND case_created_date < CURRENT_DATE - %(days)s
+        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
+          AND case_created_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood

--- a/data/marts/build_heatmap.py
+++ b/data/marts/build_heatmap.py
@@ -27,7 +27,7 @@ SELECT
     COUNT(*),
     NOW()
 FROM stg_crime
-WHERE reported_date >= CURRENT_DATE - %(days)s
+WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
 GROUP BY
     EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
@@ -43,7 +43,7 @@ SELECT
     COUNT(*),
     NOW()
 FROM stg_crashes
-WHERE reported_date >= CURRENT_DATE - %(days)s
+WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
 GROUP BY
     EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
@@ -59,7 +59,7 @@ SELECT
     COUNT(*),
     NOW()
 FROM stg_311
-WHERE case_created_date >= CURRENT_DATE - %(days)s
+WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
 GROUP BY
     EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')

--- a/data/marts/build_incident_trends.py
+++ b/data/marts/build_incident_trends.py
@@ -17,37 +17,37 @@ INSERT INTO mart_incident_trends (date, domain, category, count, updated_at)
 
 -- Crime by offense_category
 SELECT
-    reported_date::date AS date,
+    (reported_date AT TIME ZONE 'America/Denver')::date AS date,
     'crime' AS domain,
     COALESCE(offense_category, 'Unknown') AS category,
     COUNT(*) AS count,
     NOW()
 FROM stg_crime
-GROUP BY reported_date::date, offense_category
+GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, offense_category
 
 UNION ALL
 
 -- Crashes by top_offense
 SELECT
-    reported_date::date AS date,
+    (reported_date AT TIME ZONE 'America/Denver')::date AS date,
     'crashes' AS domain,
     COALESCE(top_offense, 'Unknown') AS category,
     COUNT(*) AS count,
     NOW()
 FROM stg_crashes
-GROUP BY reported_date::date, top_offense
+GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, top_offense
 
 UNION ALL
 
 -- 311 by request_type
 SELECT
-    case_created_date::date AS date,
+    (case_created_date AT TIME ZONE 'America/Denver')::date AS date,
     '311' AS domain,
     COALESCE(request_type, 'Unknown') AS category,
     COUNT(*) AS count,
     NOW()
 FROM stg_311
-GROUP BY case_created_date::date, request_type
+GROUP BY (case_created_date AT TIME ZONE 'America/Denver')::date, request_type
 
 ON CONFLICT (date, domain, category) DO UPDATE SET
     count = EXCLUDED.count,

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -51,13 +51,13 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
 ) cur ON cur.neighborhood = n.nbhd_name
@@ -68,18 +68,18 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
-          AND reported_date < CURRENT_DATE - %(days)s
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
+          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= CURRENT_DATE - %(days)s * 2
-          AND reported_date < CURRENT_DATE - %(days)s
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
+          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= CURRENT_DATE - %(days)s * 2
-          AND case_created_date < CURRENT_DATE - %(days)s
+        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
+          AND case_created_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood

--- a/data/marts/build_neighborhood_ranking.py
+++ b/data/marts/build_neighborhood_ranking.py
@@ -38,13 +38,13 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= CURRENT_DATE - %(days)s AND neighborhood IS NOT NULL
+        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
     ) all_src
     GROUP BY neighborhood
 ) c ON c.neighborhood = n.canonical_name


### PR DESCRIPTION
## Summary
- All mart builders now use `AT TIME ZONE 'America/Denver'` for `::date` casts, ensuring events are assigned to the correct Denver-local date
- Replaced `CURRENT_DATE` (UTC on Railway) with `(NOW() AT TIME ZONE 'America/Denver')::date` in all WHERE clause date filters
- Consistent with existing correct implementations in `build_heatmap.py` and AQI marts

## Affected files (7)
- `build_city_pulse_daily.py` — date grouping/joining
- `build_incident_trends.py` — date grouping
- `build_city_pulse_neighborhood.py` — WHERE clause filtering
- `build_neighborhood_comparison.py` — WHERE clause filtering
- `build_category_breakdown.py` — WHERE clause filtering
- `build_neighborhood_ranking.py` — WHERE clause filtering
- `build_heatmap.py` — WHERE clause filtering (consistency fix)

## Root cause
Pipeline runs at 06:00 UTC (midnight Denver). Without timezone conversion, `reported_date::date` casts UTC timestamps to dates, causing events after midnight UTC but before midnight Denver to be assigned to the wrong date.

## Test plan
- [x] ESLint passes
- [x] All 82 tests pass
- [ ] After merge + next pipeline run, verify dashboard shows yesterday's date
- [ ] Optionally trigger manual pipeline run in Railway to validate immediately

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)