### PR TITLE
Fix: humanize category names in Category Breakdown chart

### DIFF
--- a/__tests__/charts.test.tsx
+++ b/__tests__/charts.test.tsx
@@ -68,6 +68,20 @@ describe("CategoryChart", () => {
     render(<CategoryChart data={{}} />);
     expect(screen.getByText("No category data available")).toBeInTheDocument();
   });
+
+  it("shows summary line for single-category domain", () => {
+    const singleCategory: Record<string, CategoryBreakdown[]> = {
+      crime: [{ category: "Larceny", count: 500, percent: 100 }],
+      crashes: [],
+      requests311: [],
+    };
+    render(<CategoryChart data={singleCategory} />);
+    expect(screen.getByText("Crime")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getByText("500")).toBeInTheDocument();
+    // Should not render bar for single-category domain
+    expect(screen.queryByText("Larceny")).not.toBeInTheDocument();
+  });
 });
 
 const sampleHeatmap: HeatmapCell[] = [

--- a/components/charts/category-chart.tsx
+++ b/components/charts/category-chart.tsx
@@ -32,6 +32,24 @@ export function CategoryChart({ data }: CategoryChartProps) {
 
         const maxCount = Math.max(...items.map((i) => i.count));
 
+        // If domain has only one category, show a summary line instead of a chart
+        if (items.length === 1) {
+          const item = items[0];
+          return (
+            <div key={domain.key}>
+              <p className="text-[10px] font-semibold text-[#102A43] mb-1.5">
+                {domain.label}
+              </p>
+              <div className="flex items-center gap-2 px-1">
+                <span className="text-[9px] text-[#52667A]">Total</span>
+                <span className="text-[11px] font-medium text-[#102A43]">
+                  {formatNumber(item.count)}
+                </span>
+              </div>
+            </div>
+          );
+        }
+
         return (
           <div key={domain.key}>
             <p className="text-[10px] font-semibold text-[#102A43] mb-1.5">
@@ -40,7 +58,7 @@ export function CategoryChart({ data }: CategoryChartProps) {
             <div className="space-y-1">
               {items.slice(0, 6).map((item) => (
                 <div key={item.category} className="flex items-center gap-2">
-                  <span className="text-[9px] text-[#52667A] w-24 truncate shrink-0 text-right">
+                  <span className="text-[9px] text-[#52667A] w-24 truncate shrink-0 text-right" title={item.category}>
                     {item.category}
                   </span>
                   <div className="flex-1 h-3.5 bg-[#EEF3F8] rounded-sm overflow-hidden">

--- a/data/marts/build_category_breakdown.py
+++ b/data/marts/build_category_breakdown.py
@@ -13,46 +13,74 @@ from db import execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
+# Human-readable label for crime offense_category slugs
+CRIME_LABEL_SQL = """
+    CASE COALESCE(offense_category, 'unknown')
+        WHEN 'all-other-crimes'        THEN 'Other'
+        WHEN 'theft-from-motor-vehicle' THEN 'Vehicle Theft'
+        WHEN 'white-collar-crime'       THEN 'White-Collar Crime'
+        WHEN 'murder'                   THEN 'Homicide'
+        ELSE INITCAP(REPLACE(COALESCE(offense_category, 'Unknown'), '-', ' '))
+    END
+"""
+
+# Human-readable label for crash top_offense values
+CRASH_LABEL_SQL = """
+    CASE COALESCE(top_offense, 'Unknown')
+        WHEN 'TRAF - ACCIDENT'                        THEN 'Traffic Accident'
+        WHEN 'TRAF - ACCIDENT - HIT AND RUN'          THEN 'Hit & Run'
+        WHEN 'TRAF - ACCIDENT - DUI-DUID'             THEN 'DUI / DUID'
+        WHEN 'TRAF - ACCIDENT - SBI'                  THEN 'Serious Bodily Injury'
+        WHEN 'TRAF - ACCIDENT - POLICE'               THEN 'Police Involved'
+        WHEN 'TRAF - ACCIDENT - FATAL'                THEN 'Fatal Crash'
+        WHEN 'TRAF - HABITUAL OFFENDER'               THEN 'Habitual Offender'
+        ELSE INITCAP(REPLACE(
+            REPLACE(COALESCE(top_offense, 'Unknown'), 'TRAF - ACCIDENT - ', ''),
+            '-', ' '
+        ))
+    END
+"""
+
 # Insert counts first, then update percentages
 INSERT_SQL = """
 INSERT INTO mart_category_breakdown (
     period, domain, category, count, pct_of_total, updated_at
 )
--- Crime by offense_category
+-- Crime by offense_category (human-readable labels)
 SELECT
     %(period)s, 'crime',
-    COALESCE(offense_category, 'Unknown'),
+    {crime_label},
     COUNT(*), 0, NOW()
 FROM stg_crime
 WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
-GROUP BY offense_category
+GROUP BY {crime_label}
 
 UNION ALL
 
--- Crashes by top_offense
+-- Crashes by top_offense (human-readable labels)
 SELECT
     %(period)s, 'crashes',
-    COALESCE(top_offense, 'Unknown'),
+    {crash_label},
     COUNT(*), 0, NOW()
 FROM stg_crashes
 WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
-GROUP BY top_offense
+GROUP BY {crash_label}
 
 UNION ALL
 
--- 311 by request_type
+-- 311 by topic (request_type is usually NULL, topic has actual categories)
 SELECT
     %(period)s, '311',
-    COALESCE(request_type, 'Unknown'),
+    COALESCE(NULLIF(topic, ''), 'Other'),
     COUNT(*), 0, NOW()
 FROM stg_311
 WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
-GROUP BY request_type
+GROUP BY topic
 
 ON CONFLICT (period, domain, category) DO UPDATE SET
     count = EXCLUDED.count,
     updated_at = NOW()
-"""
+""".format(crime_label=CRIME_LABEL_SQL, crash_label=CRASH_LABEL_SQL)
 
 UPDATE_PCT_SQL = """
 UPDATE mart_category_breakdown cb


### PR DESCRIPTION
## Summary
- **Crime**: converts raw slug IDs (`public-disorder`, `all-other-crimes`, `theft-from-motor-vehicle`) to readable labels (`Public Disorder`, `Other`, `Vehicle Theft`) via SQL CASE + INITCAP
- **Crashes**: replaces `TRAF - ACCIDENT` prefix with human-readable names (`Traffic Accident`, `Hit & Run`, `DUI / DUID`, `Serious Bodily Injury`)
- **311 Requests**: switches grouping from `request_type` (always NULL) to `topic` field which has actual categories
- **Frontend**: single-category domains (e.g. if 311 still has no breakdown) show a summary total instead of a meaningless 100% bar

Closes #100

## Test plan
- [x] ESLint passes
- [x] Build passes
- [x] All 83 tests pass (1 new test for single-category fallback)
- [ ] Verify on production after next pipeline run that categories display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)