### PR TITLE
feat: stretch KPI sparklines full-width and add hover tooltips

### DIFF
--- a/__tests__/cards.test.tsx
+++ b/__tests__/cards.test.tsx
@@ -8,6 +8,7 @@ import { ErrorCard } from "@/components/cards/error-card";
 jest.mock("recharts", () => ({
   AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
   Area: () => <div />,
+  Tooltip: () => <div />,
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,6 +36,7 @@ function CityPulseContent() {
           value={kpis?.crime.value}
           deltaPercent={kpis?.crime.deltaPercent}
           sparklineData={kpis?.crime.sparkline}
+          sparklineLabel="incidents"
           insight={kpis?.crime.insight}
           color="#2458C6"
           loading={loading}
@@ -46,6 +47,7 @@ function CityPulseContent() {
           value={kpis?.crashes.value}
           deltaPercent={kpis?.crashes.deltaPercent}
           sparklineData={kpis?.crashes.sparkline}
+          sparklineLabel="crashes"
           insight={kpis?.crashes.insight}
           color="#D97904"
           loading={loading}
@@ -56,6 +58,7 @@ function CityPulseContent() {
           value={kpis?.requests311.value}
           deltaPercent={kpis?.requests311.deltaPercent}
           sparklineData={kpis?.requests311.sparkline}
+          sparklineLabel="requests"
           insight={kpis?.requests311.insight}
           color="#198754"
           loading={loading}

--- a/components/cards/kpi-card.tsx
+++ b/components/cards/kpi-card.tsx
@@ -14,6 +14,7 @@ interface KpiCardProps {
   delta?: number;
   deltaPercent?: number;
   sparklineData?: ChartPoint[];
+  sparklineLabel?: string;
   insight?: string;
   color: string;
   loading?: boolean;
@@ -26,6 +27,7 @@ export function KpiCard({
   value,
   deltaPercent,
   sparklineData = [],
+  sparklineLabel,
   insight,
   color,
   loading,
@@ -38,11 +40,8 @@ export function KpiCard({
           <Skeleton className="h-3 w-10" />
         </div>
         <Skeleton className="h-8 w-24 mb-2" />
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-4 w-14" />
-          <Skeleton className="h-7 w-20" />
-        </div>
-        <Skeleton className="h-2.5 w-full mt-2" />
+        <Skeleton className="h-4 w-14 mb-2" />
+        <Skeleton className="h-9 w-full" />
       </div>
     );
   }
@@ -60,17 +59,24 @@ export function KpiCard({
         )}
       </div>
 
-      <div className="text-[34px] font-bold text-[#102A43] leading-none mb-1">
-        {formatNumber(value)}
+      <div className="flex items-end gap-2 mb-1">
+        <span className="text-[34px] font-bold text-[#102A43] leading-none">
+          {formatNumber(value)}
+        </span>
+        <div className="mb-1">
+          <DeltaBadge value={deltaPercent} />
+        </div>
       </div>
 
-      <div className="flex items-center gap-2">
-        <DeltaBadge value={deltaPercent} />
-        <Sparkline data={sparklineData} color={color} />
-      </div>
+      <Sparkline
+        data={sparklineData}
+        color={color}
+        label={sparklineLabel}
+        height={40}
+      />
 
       {insight && (
-        <p className="text-[10px] text-[#627D98] mt-2 leading-tight line-clamp-1">
+        <p className="text-[10px] text-[#627D98] mt-1.5 leading-tight line-clamp-1">
           {insight}
         </p>
       )}

--- a/components/ui/sparkline.tsx
+++ b/components/ui/sparkline.tsx
@@ -1,33 +1,76 @@
 "use client";
 
-import { AreaChart, Area, ResponsiveContainer } from "recharts";
+import {
+  AreaChart,
+  Area,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+import { formatNumber, formatDateShort } from "@/lib/format";
 import type { ChartPoint } from "@/lib/types";
 
 interface SparklineProps {
   data: ChartPoint[];
   color: string;
-  width?: number;
+  width?: number | string;
   height?: number;
+  label?: string;
+  interactive?: boolean;
+}
+
+function SparklineTooltip({
+  active,
+  payload,
+  label: metricLabel,
+}: {
+  active?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload?: any[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0];
+  const date = formatDateShort(point.payload?.date);
+  const value = formatNumber(point.value as number);
+  return (
+    <div className="rounded-lg bg-[#102A43] px-2.5 py-1.5 text-[11px] text-white shadow-lg">
+      <span className="font-medium">{date}</span>
+      <span className="mx-1 text-white/50">·</span>
+      <span>{value} {metricLabel ?? "incidents"}</span>
+    </div>
+  );
 }
 
 export function Sparkline({
   data,
   color,
-  width = 80,
-  height = 28,
+  width = "100%",
+  height = 36,
+  label,
+  interactive = true,
 }: SparklineProps) {
   if (data.length === 0) return null;
 
   return (
     <div style={{ width, height }}>
       <ResponsiveContainer width="100%" height="100%">
-        <AreaChart data={data} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+        <AreaChart
+          data={data}
+          margin={{ top: 2, right: 2, bottom: 0, left: 2 }}
+        >
           <defs>
             <linearGradient id={`spark-${color}`} x1="0" y1="0" x2="0" y2="1">
               <stop offset="0%" stopColor={color} stopOpacity={0.3} />
               <stop offset="100%" stopColor={color} stopOpacity={0.05} />
             </linearGradient>
           </defs>
+          {interactive && (
+            <Tooltip
+              content={<SparklineTooltip label={label} />}
+              cursor={{ stroke: color, strokeOpacity: 0.3, strokeWidth: 1 }}
+              isAnimationActive={false}
+            />
+          )}
           <Area
             type="monotone"
             dataKey="value"
@@ -35,6 +78,12 @@ export function Sparkline({
             strokeWidth={1.5}
             fill={`url(#spark-${color})`}
             isAnimationActive={false}
+            activeDot={{
+              r: 3,
+              fill: color,
+              stroke: "#fff",
+              strokeWidth: 1.5,
+            }}
           />
         </AreaChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- Sparkline in KPI factoid cards now stretches to fill the full card width instead of being fixed at 80×28px
- DeltaBadge moved inline with the main value for better layout
- Interactive tooltips on sparkline hover show date and count in human-friendly format (e.g. "Mar 7 · 52 crashes")
- Active dot indicator on hover (3px circle with white border)

Closes #103

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 83 passed
- [ ] Visual check on City Pulse page — sparklines fill card width
- [ ] Hover over sparkline points — tooltip appears with date and value

🤖 Generated with [Claude Code](https://claude.com/claude-code)