### PR TITLE
Fix: sparkline tooltip label and trailing zero-days

### DIFF
--- a/components/cards/kpi-card.tsx
+++ b/components/cards/kpi-card.tsx
@@ -74,7 +74,7 @@ export function KpiCard({
           <Sparkline
             data={sparklineData}
             color={color}
-            label={sparklineLabel}
+            metricLabel={sparklineLabel}
             height={48}
           />
         </div>

--- a/components/ui/sparkline.tsx
+++ b/components/ui/sparkline.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import {
   AreaChart,
   Area,
@@ -14,31 +15,8 @@ interface SparklineProps {
   color: string;
   width?: number | string;
   height?: number;
-  label?: string;
+  metricLabel?: string;
   interactive?: boolean;
-}
-
-function SparklineTooltip({
-  active,
-  payload,
-  label: metricLabel,
-}: {
-  active?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  payload?: any[];
-  label?: string;
-}) {
-  if (!active || !payload?.length) return null;
-  const point = payload[0];
-  const date = formatDateShort(point.payload?.date);
-  const value = formatNumber(point.value as number);
-  return (
-    <div className="rounded-lg bg-[#102A43] px-2.5 py-1.5 text-[11px] text-white shadow-lg">
-      <span className="font-medium">{date}</span>
-      <span className="mx-1 text-white/50">·</span>
-      <span>{value} {metricLabel ?? "incidents"}</span>
-    </div>
-  );
 }
 
 export function Sparkline({
@@ -46,9 +24,24 @@ export function Sparkline({
   color,
   width = "100%",
   height = 36,
-  label,
+  metricLabel = "incidents",
   interactive = true,
 }: SparklineProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderTooltip = useCallback(({ active, payload }: any) => {
+    if (!active || !payload?.length) return null;
+    const point = payload[0];
+    const date = formatDateShort(point.payload?.date);
+    const value = formatNumber(point.value as number);
+    return (
+      <div className="rounded-lg bg-[#102A43] px-2.5 py-1.5 text-[11px] text-white shadow-lg">
+        <span className="font-medium">{date}</span>
+        <span className="mx-1 text-white/50">·</span>
+        <span>{value} {metricLabel}</span>
+      </div>
+    );
+  }, [metricLabel]);
+
   if (data.length === 0) return null;
 
   return (
@@ -66,7 +59,7 @@ export function Sparkline({
           </defs>
           {interactive && (
             <Tooltip
-              content={<SparklineTooltip label={label} />}
+              content={renderTooltip}
               cursor={{ stroke: color, strokeOpacity: 0.3, strokeWidth: 1 }}
               isAnimationActive={false}
             />

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -32,7 +32,9 @@ export async function getKpiSparkline(
     return query<DailyRow>(
       `SELECT date::text, crime_count, crash_count, requests_311_count
        FROM mart_city_pulse_daily
-       ORDER BY date DESC LIMIT $1`,
+       WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+       ORDER BY date DESC`,
       [days]
     );
   }
@@ -40,7 +42,9 @@ export async function getKpiSparkline(
   return query<DailyRow>(
     `SELECT date::text, crime_count, crash_count, requests_311_count
      FROM mart_city_pulse_daily
-     ORDER BY date DESC LIMIT $1`,
+     WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+       AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+     ORDER BY date DESC`,
     [days]
   );
 }
@@ -108,7 +112,7 @@ export async function getTrends(tw: TimeWindow): Promise<TrendRow[]> {
   return query<TrendRow>(
     `SELECT date::text, domain, SUM(count)::int AS count
      FROM mart_incident_trends
-     WHERE date >= CURRENT_DATE - $1::int
+     WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
      GROUP BY date, domain
      ORDER BY date`,
     [days]


### PR DESCRIPTION
## Summary
- **Tooltip bug**: Recharts was overriding the `label` prop on the tooltip content component with its internal data point index (e.g. "4"), so tooltip showed "0 4" instead of "0 incidents". Fixed by using `useCallback` render function instead of JSX element, capturing `metricLabel` via closure.
- **Zero-days bug**: `getKpiSparkline` had no date filter — it just took the N most recent rows. If `mart_city_pulse_daily` had rows for today (pipeline hasn't run yet = zero counts), they appeared as zeros. Added `date < (NOW() AT TIME ZONE 'America/Denver')::date` filter to exclude today.
- **Bonus**: Fixed `getTrends` query using `CURRENT_DATE` (server timezone) instead of Denver timezone.

Closes #106

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 83 passed
- [ ] Hover sparkline — tooltip shows "Mar 10 · 52 incidents" (not "0 4")
- [ ] Sparkline no longer drops to zero at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)