### PR TITLE
fix: invert delta badge colors and pass null deltaPercent (closes #108, #109)

### DIFF
--- a/app/api/city-pulse/kpis/route.ts
+++ b/app/api/city-pulse/kpis/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     ) => ({
       value: totals?.[countKey] ?? 0,
       delta: 0,
-      deltaPercent: totals?.[deltaKey] ?? 0,
+      deltaPercent: totals?.[deltaKey] ?? null,
       sparkline: sparkline
         .map((r) => ({ date: r.date, value: r[countKey] }))
         .reverse(),

--- a/components/ui/delta-badge.tsx
+++ b/components/ui/delta-badge.tsx
@@ -17,8 +17,8 @@ export function DeltaBadge({ value, className }: DeltaBadgeProps) {
     <span
       className={cn(
         "inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
-        isPositive && "bg-[#198754]/10 text-[#198754]",
-        isNegative && "bg-[#DC3545]/10 text-[#DC3545]",
+        isPositive && "bg-[#DC3545]/10 text-[#DC3545]",
+        isNegative && "bg-[#198754]/10 text-[#198754]",
         !isPositive && !isNegative && "bg-[#EEF3F8] text-[#627D98]",
         className
       )}


### PR DESCRIPTION
## Summary
- **Delta badge colors inverted**: positive delta (more incidents) is now red, negative (fewer) is green — correct semantics for a safety dashboard
- **NULL deltaPercent preserved**: when previous period has 0 incidents, API now returns `null` instead of `0`, so the badge renders "—" instead of misleading "0.0%"

## Changes
- `components/ui/delta-badge.tsx` — swap green/red color assignments
- `app/api/city-pulse/kpis/route.ts` — `?? 0` → `?? null`

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 83 tests pass
- [ ] Visual check: KPI cards show red for rising incidents, green for falling
- [ ] Verify null delta renders as no badge (not "0.0%")

🤖 Generated with [Claude Code](https://claude.com/claude-code)