### PR TITLE
fix: KPI date boundaries, neighborhood source, narrative avg, AQI tiebreaker (#111,#113,#114,#115)

### DIFF
--- a/data/marts/build_aqi_daily.py
+++ b/data/marts/build_aqi_daily.py
@@ -25,7 +25,7 @@ SELECT
     (
         SELECT sq.category FROM stg_aqi sq
         WHERE (sq.observed_at AT TIME ZONE 'America/Denver')::date = d.date
-        ORDER BY sq.aqi DESC
+        ORDER BY sq.aqi DESC, sq.parameter_name ASC
         LIMIT 1
     ) AS category,
     NOW()

--- a/data/marts/build_narrative_signals.py
+++ b/data/marts/build_narrative_signals.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Each signal is a separate INSERT using data from other marts
 SIGNALS = [
-    # top_domain: domain with highest total delta
+    # top_domain: domain with highest volume-weighted delta
     (
         "top_domain",
         """
@@ -29,15 +29,15 @@ SIGNALS = [
                delta_pct, 1, NOW()
         FROM (
             SELECT 'crime' AS domain,
-                   AVG(crime_delta_pct) AS delta_pct
+                   ROUND((SUM(crime_count * crime_delta_pct) / NULLIF(SUM(crime_count), 0))::numeric, 1) AS delta_pct
             FROM mart_city_pulse_neighborhood WHERE period = %(period)s AND crime_delta_pct IS NOT NULL
             UNION ALL
             SELECT 'crashes',
-                   AVG(crash_delta_pct)
+                   ROUND((SUM(crash_count * crash_delta_pct) / NULLIF(SUM(crash_count), 0))::numeric, 1)
             FROM mart_city_pulse_neighborhood WHERE period = %(period)s AND crash_delta_pct IS NOT NULL
             UNION ALL
             SELECT '311',
-                   AVG(requests_311_delta_pct)
+                   ROUND((SUM(requests_311_count * requests_311_delta_pct) / NULLIF(SUM(requests_311_count), 0))::numeric, 1)
             FROM mart_city_pulse_neighborhood WHERE period = %(period)s AND requests_311_delta_pct IS NOT NULL
         ) domains
         ORDER BY delta_pct DESC NULLS LAST

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -2,7 +2,7 @@
 Build mart_neighborhood_comparison — rates per area and deltas.
 
 For each (period, neighborhood): compute rates (incidents per sq unit from
-stg_neighborhoods.shape_area), compute delta_pct vs prior period.
+stg_neighborhoods.shape_area via ref_neighborhoods), compute delta_pct vs prior period.
 
 Periods: 7d, 30d, 90d
 """
@@ -23,14 +23,14 @@ INSERT INTO mart_neighborhood_comparison (
 )
 SELECT
     %(period)s AS period,
-    n.nbhd_name AS neighborhood,
-    CASE WHEN n.shape_area > 0
+    r.canonical_name AS neighborhood,
+    CASE WHEN COALESCE(n.shape_area, 0) > 0
          THEN ROUND((COALESCE(cur.crime, 0)::numeric / n.shape_area::numeric * 1000000)::numeric, 4)
          ELSE 0 END,
-    CASE WHEN n.shape_area > 0
+    CASE WHEN COALESCE(n.shape_area, 0) > 0
          THEN ROUND((COALESCE(cur.crashes, 0)::numeric / n.shape_area::numeric * 1000000)::numeric, 4)
          ELSE 0 END,
-    CASE WHEN n.shape_area > 0
+    CASE WHEN COALESCE(n.shape_area, 0) > 0
          THEN ROUND((COALESCE(cur.r311, 0)::numeric / n.shape_area::numeric * 1000000)::numeric, 4)
          ELSE 0 END,
     CASE WHEN COALESCE(prev.crime, 0) > 0
@@ -43,7 +43,8 @@ SELECT
          THEN ROUND(((COALESCE(cur.r311, 0) - prev.r311)::numeric / prev.r311 * 100)::numeric, 1)
          ELSE NULL END,
     NOW()
-FROM stg_neighborhoods n
+FROM ref_neighborhoods r
+LEFT JOIN stg_neighborhoods n ON n.nbhd_id = r.nbhd_id
 LEFT JOIN (
     SELECT neighborhood,
            SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
@@ -60,7 +61,7 @@ LEFT JOIN (
         WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
-) cur ON cur.neighborhood = n.nbhd_name
+) cur ON cur.neighborhood = r.canonical_name
 LEFT JOIN (
     SELECT neighborhood,
            SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
@@ -83,7 +84,7 @@ LEFT JOIN (
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood
-) prev ON prev.neighborhood = n.nbhd_name
+) prev ON prev.neighborhood = r.canonical_name
 ON CONFLICT (period, neighborhood) DO UPDATE SET
     crime_rate = EXCLUDED.crime_rate,
     crash_rate = EXCLUDED.crash_rate,

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -62,6 +62,7 @@ export async function getKpiTotals(
                 COALESCE(SUM(requests_311_count), 0)::int AS requests_311_count
          FROM mart_city_pulse_daily
          WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+           AND date < (NOW() AT TIME ZONE 'America/Denver')::date
        ),
        prev AS (
          SELECT COALESCE(SUM(crime_count), 0)::int AS crime_count,


### PR DESCRIPTION
## Summary
Four metrics calculation fixes found during data validation audit:

- **#111** — KPI totals now exclude today (partial day), matching sparkline boundaries
- **#113** — Neighborhood comparison mart uses `ref_neighborhoods` as source of truth (was `stg_neighborhoods`), joined with `stg_neighborhoods` for `shape_area`
- **#114** — Narrative `top_domain` signal uses volume-weighted average instead of unweighted AVG of delta percentages
- **#115** — AQI daily category subquery has deterministic tiebreaker (`parameter_name ASC`)

## Changes
- `lib/queries/city-pulse.ts` — add `AND date < today` to KPI totals CTE
- `data/marts/build_neighborhood_comparison.py` — switch from `stg_neighborhoods` to `ref_neighborhoods` + JOIN
- `data/marts/build_narrative_signals.py` — weighted avg: `SUM(count * delta) / SUM(count)`
- `data/marts/build_aqi_daily.py` — add `parameter_name ASC` to ORDER BY

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 83 tests pass
- [ ] Verify KPI value matches sparkline sum (no partial-day overshoot)
- [ ] Verify neighborhood comparison shows same neighborhoods as ranking
- [ ] Re-run pipeline and check narrative signals reflect weighted deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)