### PR TITLE
fix: sparkline filters by neighborhood and matches time window (closes #110, #112)

### DIFF
--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -27,25 +27,98 @@ export async function getKpiSparkline(
   tw: TimeWindow,
   neighborhood: string
 ): Promise<DailyRow[]> {
-  const days = Math.min(daysForWindow(tw), 30);
+  const days = daysForWindow(tw);
   if (neighborhood === "all") {
+    if (days <= 30) {
+      return query<DailyRow>(
+        `SELECT date::text, crime_count, crash_count, requests_311_count
+         FROM mart_city_pulse_daily
+         WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+           AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+         ORDER BY date DESC`,
+        [days]
+      );
+    }
+    // 90d: aggregate by week for a cleaner sparkline
     return query<DailyRow>(
-      `SELECT date::text, crime_count, crash_count, requests_311_count
+      `SELECT DATE_TRUNC('week', date)::date::text AS date,
+              SUM(crime_count)::int AS crime_count,
+              SUM(crash_count)::int AS crash_count,
+              SUM(requests_311_count)::int AS requests_311_count
        FROM mart_city_pulse_daily
        WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
          AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+       GROUP BY DATE_TRUNC('week', date)
        ORDER BY date DESC`,
       [days]
     );
   }
-  // When neighborhood filter is set, fall back to full daily data
+  // Neighborhood-specific sparkline from staging tables
+  if (days <= 30) {
+    return query<DailyRow>(
+      `SELECT d.date::text,
+              COALESCE(cr.cnt, 0)::int AS crime_count,
+              COALESCE(ca.cnt, 0)::int AS crash_count,
+              COALESCE(r.cnt, 0)::int AS requests_311_count
+       FROM generate_series(
+              (NOW() AT TIME ZONE 'America/Denver')::date - $1::int,
+              (NOW() AT TIME ZONE 'America/Denver')::date - 1,
+              '1 day'::interval
+            ) AS d(date)
+       LEFT JOIN (
+         SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
+         FROM stg_crime WHERE neighborhood = $2
+           AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         GROUP BY 1
+       ) cr ON cr.date = d.date
+       LEFT JOIN (
+         SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
+         FROM stg_crashes WHERE neighborhood = $2
+           AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         GROUP BY 1
+       ) ca ON ca.date = d.date
+       LEFT JOIN (
+         SELECT (case_created_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
+         FROM stg_311 WHERE neighborhood = $2
+           AND case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         GROUP BY 1
+       ) r ON r.date = d.date
+       ORDER BY d.date DESC`,
+      [days, neighborhood]
+    );
+  }
+  // 90d + neighborhood: aggregate by week
   return query<DailyRow>(
-    `SELECT date::text, crime_count, crash_count, requests_311_count
-     FROM mart_city_pulse_daily
-     WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
-       AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+    `SELECT DATE_TRUNC('week', d.date)::date::text AS date,
+            SUM(COALESCE(cr.cnt, 0))::int AS crime_count,
+            SUM(COALESCE(ca.cnt, 0))::int AS crash_count,
+            SUM(COALESCE(r.cnt, 0))::int AS requests_311_count
+     FROM generate_series(
+            (NOW() AT TIME ZONE 'America/Denver')::date - $1::int,
+            (NOW() AT TIME ZONE 'America/Denver')::date - 1,
+            '1 day'::interval
+          ) AS d(date)
+     LEFT JOIN (
+       SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
+       FROM stg_crime WHERE neighborhood = $2
+         AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+       GROUP BY 1
+     ) cr ON cr.date = d.date
+     LEFT JOIN (
+       SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
+       FROM stg_crashes WHERE neighborhood = $2
+         AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+       GROUP BY 1
+     ) ca ON ca.date = d.date
+     LEFT JOIN (
+       SELECT (case_created_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
+       FROM stg_311 WHERE neighborhood = $2
+         AND case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+       GROUP BY 1
+     ) r ON r.date = d.date
+     GROUP BY DATE_TRUNC('week', d.date)
      ORDER BY date DESC`,
-    [days]
+    [days, neighborhood]
   );
 }
 


### PR DESCRIPTION
## Summary
- **#110** — When a neighborhood is selected, sparkline now queries staging tables (`stg_crime`, `stg_crashes`, `stg_311`) with a neighborhood filter. Uses `generate_series` to produce zero-filled date spine so days with no incidents still appear in the chart.
- **#112** — Sparkline now covers the full time window: daily granularity for 7d/30d, weekly aggregation (`DATE_TRUNC('week')`) for 90d. Previously it was always capped at 30 days.

## Changes
- `lib/queries/city-pulse.ts` — rewrote `getKpiSparkline()` with 4 query paths:
  - City-wide daily (7d/30d)
  - City-wide weekly (90d)
  - Neighborhood daily (7d/30d)
  - Neighborhood weekly (90d)

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 83 tests pass
- [ ] Verify sparkline changes when selecting a neighborhood vs "all"
- [ ] Verify 90d sparkline shows ~13 weekly points instead of 30 daily points
- [ ] Verify zero-incident days appear as 0 in neighborhood sparkline (no gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)