### PR TITLE
Fix: combine header freshness line, trim KPI sparklines by effectiveThrough

### DIFF
--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -54,6 +54,8 @@ describe("City Pulse API", () => {
 
   describe("GET /api/city-pulse/kpis", () => {
     it("returns KPI data with correct shape", async () => {
+      // effectiveThrough query (called first)
+      mockQuery.mockResolvedValueOnce([{ effective_through: "2026-03-12" }]);
       // sparkline query
       mockQuery.mockResolvedValueOnce([
         { date: "2026-03-12", crime_count: 10, crash_count: 5, requests_311_count: 20 },
@@ -70,8 +72,6 @@ describe("City Pulse API", () => {
           requests_311_delta_pct: 12.0,
         },
       ]);
-      // effectiveThrough query
-      mockQuery.mockResolvedValueOnce([{ effective_through: "2026-03-12" }]);
 
       const res = await getKpis(makeRequest("http://localhost/api/city-pulse/kpis?timeWindow=30d"));
       const body = await res.json();
@@ -86,6 +86,8 @@ describe("City Pulse API", () => {
     });
 
     it("returns effectiveThrough in response", async () => {
+      // effectiveThrough query (called first)
+      mockQuery.mockResolvedValueOnce([{ effective_through: "2026-03-10" }]);
       // sparkline query
       mockQuery.mockResolvedValueOnce([
         { date: "2026-03-10", crime_count: 5, crash_count: 2, requests_311_count: 10 },
@@ -101,8 +103,6 @@ describe("City Pulse API", () => {
           requests_311_delta_pct: null,
         },
       ]);
-      // effectiveThrough query
-      mockQuery.mockResolvedValueOnce([{ effective_through: "2026-03-10" }]);
 
       const res = await getKpis(makeRequest("http://localhost/api/city-pulse/kpis?timeWindow=7d"));
       const body = await res.json();

--- a/app/api/city-pulse/kpis/route.ts
+++ b/app/api/city-pulse/kpis/route.ts
@@ -19,11 +19,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const [sparkline, totals, effectiveThrough] = await Promise.all([
+    const effectiveThrough = await getEffectiveThrough(tw);
+
+    const [sparkline, totals] = await Promise.all([
       getKpiSparkline(tw, neighborhood),
-      getKpiTotals(tw, neighborhood),
-      getEffectiveThrough(tw),
+      getKpiTotals(tw, neighborhood, effectiveThrough),
     ]);
+
+    const trimmedSparkline = effectiveThrough
+      ? sparkline.filter((r) => r.date <= effectiveThrough)
+      : sparkline;
 
     const toKpi = (
       countKey: "crime_count" | "crash_count" | "requests_311_count",
@@ -32,7 +37,7 @@ export async function GET(request: NextRequest) {
       value: totals?.[countKey] ?? 0,
       delta: 0,
       deltaPercent: totals?.[deltaKey] ?? null,
-      sparkline: sparkline
+      sparkline: trimmedSparkline
         .map((r) => ({ date: r.date, value: r[countKey] }))
         .reverse(),
       insight: "",

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -42,14 +42,11 @@ function HeaderInner({ title, subtitle, lastUpdated, effectiveThrough }: HeaderP
           {subtitle && (
             <p className="text-[11px] text-[#627D98] mt-0.5">{subtitle}</p>
           )}
-          {lastUpdated && (
+          {(lastUpdated || effectiveThrough) && (
             <p className="text-[10px] text-[#9FB3C8] mt-0.5">
-              Pipeline ran: {formatPipelineDate(lastUpdated)}
-            </p>
-          )}
-          {effectiveThrough && (
-            <p className="text-[10px] text-[#9FB3C8]">
-              Data complete through: {formatDateShort(effectiveThrough)}
+              {lastUpdated && <>Pipeline ran: {formatPipelineDate(lastUpdated)}</>}
+              {lastUpdated && effectiveThrough && <span className="mx-1">·</span>}
+              {effectiveThrough && <>Data complete through: {formatDateShort(effectiveThrough)}</>}
             </p>
           )}
         </div>

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -124,26 +124,36 @@ export async function getKpiSparkline(
 
 export async function getKpiTotals(
   tw: TimeWindow,
-  neighborhood: string
+  neighborhood: string,
+  effectiveThrough?: string | null
 ): Promise<NeighborhoodTotalRow | null> {
   if (neighborhood === "all") {
     const days = daysForWindow(tw);
+    const upperBound = effectiveThrough
+      ? `$2::date + 1`
+      : `(NOW() AT TIME ZONE 'America/Denver')::date`;
+    const prevUpperBound = effectiveThrough
+      ? `$2::date + 1 - $1::int`
+      : `(NOW() AT TIME ZONE 'America/Denver')::date - $1::int`;
+    const params: (number | string)[] = effectiveThrough
+      ? [days, effectiveThrough]
+      : [days];
     const rows = await query<NeighborhoodTotalRow>(
       `WITH cur AS (
          SELECT COALESCE(SUM(crime_count), 0)::int AS crime_count,
                 COALESCE(SUM(crash_count), 0)::int AS crash_count,
                 COALESCE(SUM(requests_311_count), 0)::int AS requests_311_count
          FROM mart_city_pulse_daily
-         WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
-           AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+         WHERE date >= ${upperBound} - $1::int
+           AND date < ${upperBound}
        ),
        prev AS (
          SELECT COALESCE(SUM(crime_count), 0)::int AS crime_count,
                 COALESCE(SUM(crash_count), 0)::int AS crash_count,
                 COALESCE(SUM(requests_311_count), 0)::int AS requests_311_count
          FROM mart_city_pulse_daily
-         WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int * 2
-           AND date < (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         WHERE date >= ${prevUpperBound} - $1::int
+           AND date < ${prevUpperBound}
        )
        SELECT
          cur.crime_count,
@@ -159,7 +169,7 @@ export async function getKpiTotals(
               THEN ROUND(((cur.requests_311_count - prev.requests_311_count)::numeric / prev.requests_311_count) * 100, 1)
               ELSE NULL END AS requests_311_delta_pct
        FROM cur, prev`,
-      [days]
+      params
     );
     return rows[0] ?? null;
   }


### PR DESCRIPTION
## Summary
- **Header**: merged "Pipeline ran" and "Data complete through" into a single line with a `·` separator to reduce vertical whitespace
- **KPI sparklines**: filtered sparkline data by `effectiveThrough` so zero-data days after the cutoff are no longer shown
- **KPI totals**: `getKpiTotals()` now accepts optional `effectiveThrough` param to use as the upper date bound, so totals and deltas reflect only complete-data days

Closes #121

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] All 88 tests pass (updated mock order in api-city-pulse tests)
- [ ] Visual: verify header shows one line with separator
- [ ] Visual: verify KPI sparklines no longer drop to zero after effectiveThrough date

🤖 Generated with [Claude Code](https://claude.com/claude-code)