### PR TITLE
Fix: prevent mart data loss when ingestion fails

### DIFF
--- a/data/marts/build_aqi_daily.py
+++ b/data/marts/build_aqi_daily.py
@@ -9,7 +9,7 @@ Uses UPSERT for idempotency.
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,16 @@ def build() -> dict:
     """Build the mart_aqi_daily table."""
     start = time.time()
     logger.info("Building mart_aqi_daily")
+
+    source_count = count_rows("stg_aqi")
+    if source_count == 0:
+        logger.warning("stg_aqi is empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_aqi_daily",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_aqi_daily")
     rows = execute_sql(BUILD_SQL)

--- a/data/marts/build_category_breakdown.py
+++ b/data/marts/build_category_breakdown.py
@@ -9,7 +9,7 @@ Periods: 7d, 30d, 90d
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,16 @@ PERIODS = [("7d", 7), ("30d", 30), ("90d", 90)]
 def build() -> dict:
     start = time.time()
     logger.info("Building mart_category_breakdown")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_category_breakdown",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_category_breakdown")
     total_rows = 0

--- a/data/marts/build_city_pulse_daily.py
+++ b/data/marts/build_city_pulse_daily.py
@@ -8,7 +8,7 @@ Uses UPSERT (ON CONFLICT DO UPDATE) for idempotency.
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,16 @@ def build() -> dict:
     """Build the mart_city_pulse_daily table."""
     start = time.time()
     logger.info("Building mart_city_pulse_daily")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_city_pulse_daily",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_city_pulse_daily")
     rows = execute_sql(BUILD_SQL)

--- a/data/marts/build_city_pulse_neighborhood.py
+++ b/data/marts/build_city_pulse_neighborhood.py
@@ -11,7 +11,7 @@ Delta: ((current - prior) / prior) * 100, NULL if prior = 0.
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +114,16 @@ def build() -> dict:
     """Build the mart_city_pulse_neighborhood table."""
     start = time.time()
     logger.info("Building mart_city_pulse_neighborhood")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_city_pulse_neighborhood",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_city_pulse_neighborhood")
     total_rows = 0

--- a/data/marts/build_heatmap.py
+++ b/data/marts/build_heatmap.py
@@ -10,7 +10,7 @@ Periods: 7d, 30d, 90d
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +75,16 @@ PERIODS = [("7d", 7), ("30d", 30), ("90d", 90)]
 def build() -> dict:
     start = time.time()
     logger.info("Building mart_heatmap_hour_day")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_heatmap_hour_day",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_heatmap_hour_day")
     total_rows = 0

--- a/data/marts/build_incident_trends.py
+++ b/data/marts/build_incident_trends.py
@@ -8,7 +8,7 @@ Uses UPSERT for idempotency.
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,16 @@ def build() -> dict:
     """Build the mart_incident_trends table."""
     start = time.time()
     logger.info("Building mart_incident_trends")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_incident_trends",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_incident_trends")
     rows = execute_sql(BUILD_SQL)

--- a/data/marts/build_narrative_signals.py
+++ b/data/marts/build_narrative_signals.py
@@ -14,7 +14,7 @@ Periods: 7d, 30d, 90d
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +132,21 @@ PERIODS = [("7d", 7), ("30d", 30), ("90d", 90)]
 def build() -> dict:
     start = time.time()
     logger.info("Building mart_narrative_signals")
+
+    source_count = (
+        count_rows("mart_city_pulse_neighborhood")
+        + count_rows("mart_neighborhood_ranking")
+        + count_rows("mart_category_breakdown")
+        + count_rows("mart_aqi_daily")
+    )
+    if source_count == 0:
+        logger.warning("All source marts empty — skipping build to preserve existing signals")
+        return {
+            "source": "mart_narrative_signals",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_narrative_signals")
     total_rows = 0

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -10,7 +10,7 @@ Periods: 7d, 30d, 90d
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,16 @@ def build() -> dict:
     """Build the mart_neighborhood_comparison table."""
     start = time.time()
     logger.info("Building mart_neighborhood_comparison")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_neighborhood_comparison",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_neighborhood_comparison")
     total_rows = 0

--- a/data/marts/build_neighborhood_ranking.py
+++ b/data/marts/build_neighborhood_ranking.py
@@ -10,7 +10,7 @@ Periods: 7d, 30d, 90d
 import logging
 import time
 
-from db import execute_sql, truncate_table
+from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +101,16 @@ def build() -> dict:
     """Build the mart_neighborhood_ranking table."""
     start = time.time()
     logger.info("Building mart_neighborhood_ranking")
+
+    source_count = count_rows("stg_crime") + count_rows("stg_crashes") + count_rows("stg_311")
+    if source_count == 0:
+        logger.warning("All staging tables empty — skipping build to preserve existing mart data")
+        return {
+            "source": "mart_neighborhood_ranking",
+            "status": "skipped",
+            "inserted": 0,
+            "duration_s": round(time.time() - start, 1),
+        }
 
     truncate_table("mart_neighborhood_ranking")
     total_rows = 0

--- a/data/marts/db.py
+++ b/data/marts/db.py
@@ -44,3 +44,14 @@ def fetch_rows(sql: str, params: tuple = ()) -> list[tuple]:
             return cur.fetchall()
     finally:
         conn.close()
+
+
+def count_rows(table: str) -> int:
+    """Return the number of rows in a table."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {table}")  # noqa: S608 — table name is always a literal from our code
+            return cur.fetchone()[0]
+    finally:
+        conn.close()

--- a/data/marts/tests/test_empty_source_guard.py
+++ b/data/marts/tests/test_empty_source_guard.py
@@ -1,0 +1,131 @@
+"""Tests for empty-source guard in all mart builders.
+
+Each mart builder must return status="skipped" when its source tables are empty,
+preserving existing mart data instead of truncating it.
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "staging"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _make_count_rows(empty_tables: set[str]):
+    """Return a count_rows mock that returns 0 for specified tables."""
+    def mock_count_rows(table: str) -> int:
+        return 0 if table in empty_tables else 100
+    return mock_count_rows
+
+
+class TestAqiDailyGuard:
+    """build_aqi_daily must skip when stg_aqi is empty."""
+
+    @patch("build_aqi_daily.truncate_table")
+    @patch("build_aqi_daily.count_rows", return_value=0)
+    def test_skips_when_stg_aqi_empty(self, mock_count, mock_truncate):
+        from build_aqi_daily import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+    @patch("build_aqi_daily.execute_sql", return_value=90)
+    @patch("build_aqi_daily.truncate_table")
+    @patch("build_aqi_daily.count_rows", return_value=500)
+    def test_builds_when_stg_aqi_has_data(self, mock_count, mock_truncate, mock_exec):
+        from build_aqi_daily import build
+        result = build()
+        assert result["status"] == "ok"
+        mock_truncate.assert_called_once_with("mart_aqi_daily")
+
+
+class TestCityPulseDailyGuard:
+    """build_city_pulse_daily must skip when all staging tables are empty."""
+
+    @patch("build_city_pulse_daily.truncate_table")
+    @patch("build_city_pulse_daily.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_city_pulse_daily import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+    @patch("build_city_pulse_daily.execute_sql", return_value=30)
+    @patch("build_city_pulse_daily.truncate_table")
+    @patch("build_city_pulse_daily.count_rows", side_effect=_make_count_rows({"stg_crashes"}))
+    def test_builds_when_at_least_one_has_data(self, mock_count, mock_truncate, mock_exec):
+        from build_city_pulse_daily import build
+        result = build()
+        assert result["status"] == "ok"
+        mock_truncate.assert_called_once()
+
+
+class TestIncidentTrendsGuard:
+    @patch("build_incident_trends.truncate_table")
+    @patch("build_incident_trends.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_incident_trends import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+
+class TestHeatmapGuard:
+    @patch("build_heatmap.truncate_table")
+    @patch("build_heatmap.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_heatmap import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+
+class TestNeighborhoodRankingGuard:
+    @patch("build_neighborhood_ranking.truncate_table")
+    @patch("build_neighborhood_ranking.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_neighborhood_ranking import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+
+class TestCategoryBreakdownGuard:
+    @patch("build_category_breakdown.truncate_table")
+    @patch("build_category_breakdown.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_category_breakdown import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+
+class TestCityPulseNeighborhoodGuard:
+    @patch("build_city_pulse_neighborhood.truncate_table")
+    @patch("build_city_pulse_neighborhood.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_city_pulse_neighborhood import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+
+class TestNeighborhoodComparisonGuard:
+    @patch("build_neighborhood_comparison.truncate_table")
+    @patch("build_neighborhood_comparison.count_rows", return_value=0)
+    def test_skips_when_all_staging_empty(self, mock_count, mock_truncate):
+        from build_neighborhood_comparison import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()
+
+
+class TestNarrativeSignalsGuard:
+    @patch("build_narrative_signals.truncate_table")
+    @patch("build_narrative_signals.count_rows", return_value=0)
+    def test_skips_when_all_source_marts_empty(self, mock_count, mock_truncate):
+        from build_narrative_signals import build
+        result = build()
+        assert result["status"] == "skipped"
+        mock_truncate.assert_not_called()


### PR DESCRIPTION
## Summary
- All 9 mart builders now check source table row counts before truncating
- If source tables are empty, build is skipped (`status: "skipped"`) preserving existing data
- Added `count_rows()` helper to `data/marts/db.py`
- 11 new tests covering empty-source guard for every mart builder

Closes #123

## Root Cause
When AQI ingestion fails (missing `AIRNOW_API_KEY` or API issues), `build_aqi_daily.py` unconditionally truncates `mart_aqi_daily` then inserts 0 rows from empty `stg_aqi` — destroying all historical data.

Same pattern existed in all 9 mart builders.

## Manual action needed
Check that `AIRNOW_API_KEY` is set in Railway environment variables — this fix prevents data loss but won't restore data if the key is missing.

## Test plan
- [x] 11 new tests: empty source → skipped, non-empty source → builds normally
- [x] All existing mart tests pass (70/71, 1 pre-existing failure unrelated)
- [x] All staging tests pass (68/68)
- [x] All frontend tests pass (88/88)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)