### PR TITLE
feat: change heatmap aggregation from SUM to AVG (closes #137)

### DIFF
--- a/components/charts/heatmap-chart.tsx
+++ b/components/charts/heatmap-chart.tsx
@@ -118,7 +118,7 @@ export function HeatmapChart({ data }: HeatmapChartProps) {
           style={{ left: tooltip.x, top: tooltip.y }}
         >
           <p className="text-[10px] text-[#102A43] font-medium whitespace-nowrap">
-            {DAY_LABELS[tooltip.day]} {HOUR_LABELS[tooltip.hour]} — {tooltip.count} incidents
+            {DAY_LABELS[tooltip.day]} {HOUR_LABELS[tooltip.hour]} — Avg per week: {tooltip.count} incidents
           </p>
         </div>
       )}

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -231,7 +231,7 @@ export async function getHeatmap(
 ): Promise<HeatmapRow[]> {
   if (domain === "all") {
     return query<HeatmapRow>(
-      `SELECT day_of_week, hour_of_day, SUM(count)::int AS count
+      `SELECT day_of_week, hour_of_day, ROUND(AVG(count))::int AS count
        FROM mart_heatmap_hour_day
        WHERE period = $1
        GROUP BY day_of_week, hour_of_day


### PR DESCRIPTION
## Summary
- Changed heatmap SQL from `SUM(count)` to `ROUND(AVG(count))` for domain=all aggregation
- Updated tooltip text to "Avg per week: N incidents"

Closes #137

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)