### PR TITLE
feat: increase bar radius on Change Leaders chart (closes #138)

### DIFF
--- a/components/charts/change-leaders-chart.tsx
+++ b/components/charts/change-leaders-chart.tsx
@@ -116,7 +116,7 @@ export function ChangeLeadersChart({ data }: ChangeLeadersChartProps) {
         />
         <ReferenceLine x={0} stroke="#DDE3EA" />
         <Tooltip content={<CustomTooltip />} />
-        <Bar dataKey="delta" isAnimationActive={false} radius={[2, 2, 2, 2]}>
+        <Bar dataKey="delta" isAnimationActive={false} radius={[4, 4, 4, 4]}>
           {leaders.map((entry, i) => (
             <Cell
               key={i}


### PR DESCRIPTION
## Summary
- Increased bar corner radius from 2px to 4px on Change Leaders horizontal bars
- Matches the rounded-sm feel of Category Breakdown

Closes #138

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)