### PR TITLE
feat: verify and fix responsive layout for all viewports (closes #140)

### DIFF
--- a/__tests__/page-city-pulse.test.tsx
+++ b/__tests__/page-city-pulse.test.tsx
@@ -154,6 +154,25 @@ describe("CityPulsePage", () => {
     expect(screen.getByText("Change Leaders")).toBeInTheDocument();
   });
 
+  it("uses responsive grid classes for layout", () => {
+    mockUseCityPulseData.mockReturnValue({
+      kpis: null,
+      categories: {},
+      heatmap: [],
+      neighborhoods: [],
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(<CityPulsePage />);
+    // KPI row: 1-col mobile, 2-col sm, 4-col lg
+    expect(container.querySelector(".grid-cols-1.sm\\:grid-cols-2.lg\\:grid-cols-4")).toBeInTheDocument();
+    // Map + categories row: 1-col mobile, 5-col lg
+    expect(container.querySelector(".grid-cols-1.lg\\:grid-cols-5")).toBeInTheDocument();
+    // AQI + heatmap row: 1-col mobile, 2-col md
+    expect(container.querySelector(".grid-cols-1.md\\:grid-cols-2")).toBeInTheDocument();
+  });
+
   it("renders error state", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -47,7 +47,7 @@ function HeaderInner({ lastUpdated, effectiveThrough }: HeaderProps) {
         </div>
       </div>
 
-      <div className="flex items-center gap-2 w-full sm:w-auto">
+      <div className="flex items-center gap-2 w-full sm:w-auto min-w-0">
         <TimeWindowFilter value={timeWindow} onChange={setTimeWindow} />
         <NeighborhoodFilter value={neighborhood} onChange={setNeighborhood} />
       </div>

--- a/components/layout/neighborhood-filter.tsx
+++ b/components/layout/neighborhood-filter.tsx
@@ -30,7 +30,7 @@ export function NeighborhoodFilter({
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="rounded-full bg-[#EEF4FA] border border-[#C7D5E6] px-3 py-1.5 text-xs font-medium text-[#52667A] cursor-pointer hover:bg-[#E0E8F0] appearance-none pr-7"
+      className="rounded-full bg-[#EEF4FA] border border-[#C7D5E6] px-3 py-1.5 text-xs font-medium text-[#52667A] cursor-pointer hover:bg-[#E0E8F0] appearance-none pr-7 min-w-0 max-w-full truncate"
       style={{
         backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2352667A' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")`,
         backgroundRepeat: "no-repeat",


### PR DESCRIPTION
## Summary
- Verified responsive grid classes: KPI (1→2→4 cols), Map+Categories (1→5 cols), AQI+Heatmap (1→2 cols)
- Added `min-w-0` to header filters container to prevent overflow
- Added `min-w-0 max-w-full truncate` to neighborhood select for long names on mobile
- Added test verifying responsive grid classes are applied

Closes #140

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 69 passed (1 new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)