### PR TITLE
Fix: chart height alignment and global date cutoff

### DIFF
--- a/__tests__/cards.test.tsx
+++ b/__tests__/cards.test.tsx
@@ -70,6 +70,31 @@ describe("ChartCard", () => {
     const skeletons = container.querySelectorAll(".animate-pulse");
     expect(skeletons.length).toBeGreaterThan(0);
   });
+
+  it("uses flex layout for height stretching", () => {
+    const { container } = render(
+      <ChartCard title="Map" className="h-full">
+        <div>content</div>
+      </ChartCard>
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain("flex");
+    expect(card.className).toContain("flex-col");
+    expect(card.className).toContain("h-full");
+    // inner content area should grow
+    const inner = card.querySelector(".flex-1");
+    expect(inner).toBeInTheDocument();
+  });
+
+  it("passes custom className", () => {
+    const { container } = render(
+      <ChartCard title="Test" className="custom-class">
+        <div />
+      </ChartCard>
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain("custom-class");
+  });
 });
 
 describe("ErrorCard", () => {

--- a/__tests__/page-city-pulse.test.tsx
+++ b/__tests__/page-city-pulse.test.tsx
@@ -173,6 +173,41 @@ describe("CityPulsePage", () => {
     expect(container.querySelector(".grid-cols-1.md\\:grid-cols-2")).toBeInTheDocument();
   });
 
+  it("uses global effectiveThrough (min of city-pulse and environment)", () => {
+    mockUseCityPulseData.mockReturnValue({
+      kpis: null,
+      categories: {},
+      heatmap: [],
+      neighborhoods: [],
+      effectiveThrough: "2026-03-09",
+      lastUpdated: "2026-03-16T06:00:00Z",
+      loading: false,
+      error: null,
+      retry: jest.fn(),
+    });
+    mockUseEnvironmentData.mockReturnValue({
+      aqi: {
+        current: { aqi: 42, status: "Good" },
+        trend: [
+          { date: "2026-03-08", aqiMax: 40, aqiOzone: 30, aqiPm25: 20, aqiPm10: 15, category: "Good" },
+          { date: "2026-03-09", aqiMax: 45, aqiOzone: 35, aqiPm25: 25, aqiPm10: 18, category: "Good" },
+          { date: "2026-03-15", aqiMax: 50, aqiOzone: 40, aqiPm25: 30, aqiPm10: 20, category: "Good" },
+        ],
+      },
+      comparison: [],
+      effectiveThrough: "2026-03-15",
+      lastUpdated: "2026-03-16T06:00:00Z",
+      loading: false,
+      error: null,
+      retry: jest.fn(),
+    } as ReturnType<typeof useEnvironmentData>);
+
+    render(<CityPulsePage />);
+    // Header should show the earlier date (Mar 9), not the later one (Mar 15)
+    expect(screen.getByText(/Mar 9/)).toBeInTheDocument();
+    expect(screen.queryByText(/Mar 15/)).not.toBeInTheDocument();
+  });
+
   it("renders error state", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,8 +20,18 @@ function CityPulseContent() {
   const { timeWindow, neighborhood } = useFilters();
   const { kpis, categories, heatmap, neighborhoods, loading, error, retry, effectiveThrough, lastUpdated } =
     useCityPulseData(timeWindow, neighborhood);
-  const { aqi, comparison, loading: envLoading, error: envError, retry: envRetry } =
+  const { aqi, comparison, loading: envLoading, error: envError, retry: envRetry, effectiveThrough: envEffectiveThrough } =
     useEnvironmentData(timeWindow, neighborhood);
+
+  // Global cutoff: the earliest effectiveThrough across all data sources
+  const globalEffectiveThrough = effectiveThrough && envEffectiveThrough
+    ? (effectiveThrough < envEffectiveThrough ? effectiveThrough : envEffectiveThrough)
+    : effectiveThrough ?? envEffectiveThrough;
+
+  // Filter AQI trend to global cutoff so all charts show the same date range
+  const trimmedAqiTrend = globalEffectiveThrough
+    ? aqi.trend.filter((p) => p.date <= globalEffectiveThrough)
+    : aqi.trend;
 
   const combinedError = error || envError;
 
@@ -44,7 +54,7 @@ function CityPulseContent() {
       title="Denver Urban Pulse"
       subtitle="Crime, crashes, 311 requests, and air quality across Denver"
       lastUpdated={lastUpdated}
-      effectiveThrough={effectiveThrough}
+      effectiveThrough={globalEffectiveThrough}
     >
       {/* Row 1: KPI Strip — 4 cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
@@ -92,9 +102,9 @@ function CityPulseContent() {
       </div>
 
       {/* Row 2: Neighborhood Map (60%) + Category Breakdown (40%) */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3">
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3 items-stretch">
         <div className="lg:col-span-3">
-          <ChartCard title="Neighborhood Map" loading={loading}>
+          <ChartCard title="Neighborhood Map" loading={loading} className="h-full">
             <div className="h-64 md:h-[300px] -m-2 rounded-lg overflow-hidden">
               <DenverMapDynamic
                 geojson={geojson as unknown as GeoJSON.FeatureCollection}
@@ -105,7 +115,7 @@ function CityPulseContent() {
           </ChartCard>
         </div>
         <div className="lg:col-span-2">
-          <ChartCard title="Category Breakdown" loading={loading}>
+          <ChartCard title="Category Breakdown" loading={loading} className="h-full">
             <CategoryChart data={categories} />
           </ChartCard>
         </div>
@@ -114,7 +124,7 @@ function CityPulseContent() {
       {/* Row 3: AQI Trend (50%) + Time Heatmap (50%) */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <ChartCard title="AQI Trend" loading={envLoading}>
-          <AqiTrendChart data={aqi.trend} />
+          <AqiTrendChart data={trimmedAqiTrend} />
         </ChartCard>
         <ChartCard title="Time Heatmap" loading={loading}>
           <HeatmapChart data={heatmap} />

--- a/components/cards/chart-card.tsx
+++ b/components/cards/chart-card.tsx
@@ -5,12 +5,13 @@ interface ChartCardProps {
   children: React.ReactNode;
   insight?: string;
   loading?: boolean;
+  className?: string;
 }
 
-export function ChartCard({ title, children, insight, loading }: ChartCardProps) {
+export function ChartCard({ title, children, insight, loading, className }: ChartCardProps) {
   if (loading) {
     return (
-      <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+      <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] ${className ?? ""}`}>
         <Skeleton className="h-3.5 w-32 mb-3" />
         <Skeleton className="h-48 w-full rounded-lg" />
         <Skeleton className="h-2.5 w-2/3 mt-3" />
@@ -19,9 +20,9 @@ export function ChartCard({ title, children, insight, loading }: ChartCardProps)
   }
 
   return (
-    <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+    <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] flex flex-col ${className ?? ""}`}>
       <h3 className="text-xs font-bold text-[#102A43] mb-2 truncate">{title}</h3>
-      <div className="bg-[#F8FAFC] rounded-lg p-2">{children}</div>
+      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1">{children}</div>
       {insight && (
         <p className="text-[10px] text-[#6B7B8D] mt-2 leading-tight">
           {insight}


### PR DESCRIPTION
## Summary
- **#147**: ChartCard now uses `flex flex-col` layout with `className` prop; Row 2 grid uses `items-stretch` + `h-full` so Neighborhood Map and Category Breakdown cards match in height
- **#148**: Compute `globalEffectiveThrough = min(cityPulse, environment)` on the frontend; filter AQI trend data by this cutoff so all charts consistently end at the same date; header displays the global date

Closes #147, closes #148

## Test plan
- [x] Regression test: ChartCard flex layout and className passthrough
- [x] Regression test: global effectiveThrough filters out AQI data beyond city-pulse cutoff
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 72 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)