### PR TITLE
refactor: unify dashboard layout to 12-column grid

### DIFF
--- a/__tests__/page-city-pulse.test.tsx
+++ b/__tests__/page-city-pulse.test.tsx
@@ -165,12 +165,12 @@ describe("CityPulsePage", () => {
     });
 
     const { container } = render(<CityPulsePage />);
-    // KPI row: 1-col mobile, 2-col sm, 4-col lg
-    expect(container.querySelector(".grid-cols-1.sm\\:grid-cols-2.lg\\:grid-cols-4")).toBeInTheDocument();
-    // Map + categories row: 1-col mobile, 5-col lg
-    expect(container.querySelector(".grid-cols-1.lg\\:grid-cols-5")).toBeInTheDocument();
-    // AQI + heatmap row: 1-col mobile, 2-col md
-    expect(container.querySelector(".grid-cols-1.md\\:grid-cols-2")).toBeInTheDocument();
+    // KPI row: 1-col mobile, 2-col sm, 12-col lg
+    expect(container.querySelector(".grid-cols-1.sm\\:grid-cols-2.lg\\:grid-cols-12")).toBeInTheDocument();
+    // Map + categories row: 1-col mobile, 12-col lg
+    expect(container.querySelector(".grid-cols-1.lg\\:grid-cols-12")).toBeInTheDocument();
+    // AQI + heatmap row: 1-col mobile, 12-col md
+    expect(container.querySelector(".grid-cols-1.md\\:grid-cols-12")).toBeInTheDocument();
   });
 
   it("uses global effectiveThrough (min of city-pulse and environment)", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,8 +57,9 @@ function CityPulseContent() {
       effectiveThrough={globalEffectiveThrough}
     >
       {/* Row 1: KPI Strip — 4 cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-3">
         <KpiCard
+          className="lg:col-span-3"
           title="Crime Incidents"
           tag={tagLabel}
           value={kpis?.crime.value}
@@ -70,6 +71,7 @@ function CityPulseContent() {
           loading={loading}
         />
         <KpiCard
+          className="lg:col-span-3"
           title="Traffic Crashes"
           tag={tagLabel}
           value={kpis?.crashes.value}
@@ -81,6 +83,7 @@ function CityPulseContent() {
           loading={loading}
         />
         <KpiCard
+          className="lg:col-span-3"
           title="311 Requests"
           tag={tagLabel}
           value={kpis?.requests311.value}
@@ -92,6 +95,7 @@ function CityPulseContent() {
           loading={loading}
         />
         <KpiCard
+          className="lg:col-span-3"
           title="Air Quality Index"
           tag="Current"
           secondaryTag={aqiInfo?.label}
@@ -101,9 +105,9 @@ function CityPulseContent() {
         />
       </div>
 
-      {/* Row 2: Neighborhood Map (60%) + Category Breakdown (40%) */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3 items-stretch">
-        <div className="lg:col-span-3">
+      {/* Row 2: Neighborhood Map (7/12) + Category Breakdown (5/12) */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 items-stretch">
+        <div className="lg:col-span-7">
           <ChartCard title="Neighborhood Map" loading={loading} className="h-full">
             <div className="h-64 md:h-[300px] -m-2 rounded-lg overflow-hidden">
               <DenverMapDynamic
@@ -114,19 +118,19 @@ function CityPulseContent() {
             </div>
           </ChartCard>
         </div>
-        <div className="lg:col-span-2">
+        <div className="lg:col-span-5">
           <ChartCard title="Category Breakdown" loading={loading} className="h-full">
             <CategoryChart data={categories} />
           </ChartCard>
         </div>
       </div>
 
-      {/* Row 3: AQI Trend (50%) + Time Heatmap (50%) */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <ChartCard title="AQI Trend" loading={envLoading}>
+      {/* Row 3: AQI Trend (6/12) + Time Heatmap (6/12) */}
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
+        <ChartCard title="AQI Trend" loading={envLoading} className="md:col-span-6">
           <AqiTrendChart data={trimmedAqiTrend} />
         </ChartCard>
-        <ChartCard title="Time Heatmap" loading={loading}>
+        <ChartCard title="Time Heatmap" loading={loading} className="md:col-span-6">
           <HeatmapChart data={heatmap} />
         </ChartCard>
       </div>
@@ -153,28 +157,28 @@ function CityPulseSkeleton() {
       title="Denver Urban Pulse"
       subtitle="Crime, crashes, 311 requests, and air quality across Denver"
     >
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-3">
         {[0, 1, 2, 3].map((i) => (
-          <KpiCard key={i} title="" value={0} color="#ccc" loading />
+          <KpiCard key={i} className="lg:col-span-3" title="" value={0} color="#ccc" loading />
         ))}
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3">
-        <div className="lg:col-span-3">
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3">
+        <div className="lg:col-span-7">
           <ChartCard title="Neighborhood Map" loading>
             <div className="h-48" />
           </ChartCard>
         </div>
-        <div className="lg:col-span-2">
+        <div className="lg:col-span-5">
           <ChartCard title="Category Breakdown" loading>
             <div className="h-48" />
           </ChartCard>
         </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <ChartCard title="AQI Trend" loading>
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
+        <ChartCard title="AQI Trend" loading className="md:col-span-6">
           <div className="h-48" />
         </ChartCard>
-        <ChartCard title="Time Heatmap" loading>
+        <ChartCard title="Time Heatmap" loading className="md:col-span-6">
           <div className="h-48" />
         </ChartCard>
       </div>

--- a/components/cards/kpi-card.tsx
+++ b/components/cards/kpi-card.tsx
@@ -18,6 +18,7 @@ interface KpiCardProps {
   insight?: string;
   color: string;
   loading?: boolean;
+  className?: string;
 }
 
 export function KpiCard({
@@ -31,10 +32,11 @@ export function KpiCard({
   insight,
   color,
   loading,
+  className,
 }: KpiCardProps) {
   if (loading) {
     return (
-      <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+      <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] ${className ?? ""}`}>
         <div className="flex items-center justify-between mb-2">
           <Skeleton className="h-3 w-20" />
           <Skeleton className="h-3 w-10" />
@@ -51,7 +53,7 @@ export function KpiCard({
   }
 
   return (
-    <div className="rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310]">
+    <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] ${className ?? ""}`}>
       <div className="flex items-center justify-between mb-1">
         <span className="text-[11px] font-bold text-[#52667A] uppercase tracking-wide">
           {title}


### PR DESCRIPTION
## Summary
- Converted all dashboard rows from mixed grids (`grid-cols-4`, `grid-cols-5`, `grid-cols-2`) to a unified `grid-cols-12` system
- KPI strip: 4 × `col-span-3`, Map row: 7+5, AQI row: 6+6
- Added `className` prop to `KpiCard` for grid placement
- Updated skeleton layout to match
- Updated layout tests

Closes #150

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — all 72 tests pass
- [ ] Visual check: verify vertical alignment of card edges across rows on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)