### PR TITLE
refactor: align AQI+Heatmap row to 7+5 grid matching Map row

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -125,12 +125,12 @@ function CityPulseContent() {
         </div>
       </div>
 
-      {/* Row 3: AQI Trend (6/12) + Time Heatmap (6/12) */}
+      {/* Row 3: AQI Trend (7/12) + Time Heatmap (5/12) */}
       <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
-        <ChartCard title="AQI Trend" loading={envLoading} className="md:col-span-6">
+        <ChartCard title="AQI Trend" loading={envLoading} className="md:col-span-7">
           <AqiTrendChart data={trimmedAqiTrend} />
         </ChartCard>
-        <ChartCard title="Time Heatmap" loading={loading} className="md:col-span-6">
+        <ChartCard title="Time Heatmap" loading={loading} className="md:col-span-5">
           <HeatmapChart data={heatmap} />
         </ChartCard>
       </div>
@@ -175,10 +175,10 @@ function CityPulseSkeleton() {
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
-        <ChartCard title="AQI Trend" loading className="md:col-span-6">
+        <ChartCard title="AQI Trend" loading className="md:col-span-7">
           <div className="h-48" />
         </ChartCard>
-        <ChartCard title="Time Heatmap" loading className="md:col-span-6">
+        <ChartCard title="Time Heatmap" loading className="md:col-span-5">
           <div className="h-48" />
         </ChartCard>
       </div>


### PR DESCRIPTION
## Summary
- Changed Row 3 (AQI Trend + Time Heatmap) from 6+6 to 7+5 split
- Now both Row 2 and Row 3 share the same vertical boundary at column 7, creating consistent alignment

Closes #150

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — all 72 tests pass
- [ ] Visual check: verify left/right card edges align vertically between rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)