### PR TITLE
Fix: neighborhood map fills full card height

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,7 +109,7 @@ function CityPulseContent() {
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 items-stretch">
         <div className="lg:col-span-7">
           <ChartCard title="Neighborhood Map" loading={loading} className="h-full">
-            <div className="h-64 md:h-[300px] -m-2 rounded-lg overflow-hidden">
+            <div className="flex-1 min-h-[200px] -m-2 rounded-lg overflow-hidden">
               <DenverMapDynamic
                 geojson={geojson as unknown as GeoJSON.FeatureCollection}
                 data={neighborhoods}

--- a/components/cards/chart-card.tsx
+++ b/components/cards/chart-card.tsx
@@ -22,7 +22,7 @@ export function ChartCard({ title, children, insight, loading, className }: Char
   return (
     <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] flex flex-col ${className ?? ""}`}>
       <h3 className="text-xs font-bold text-[#102A43] mb-2 truncate">{title}</h3>
-      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1">{children}</div>
+      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1 flex flex-col min-h-0">{children}</div>
       {insight && (
         <p className="text-[10px] text-[#6B7B8D] mt-2 leading-tight">
           {insight}


### PR DESCRIPTION
## Summary
- ChartCard content wrapper now uses `flex flex-col min-h-0` so children can fill height via flex
- Map container uses `flex-1 min-h-[200px]` instead of fixed `h-64 md:h-[300px]`, eliminating the empty gap below the map

Closes #153

## Test plan
- [ ] Verify map fills full card height on City Pulse page (no empty space below)
- [ ] Verify other ChartCards (Category Breakdown, AQI Trend, Heatmap, Change Leaders) render correctly
- [ ] Check responsive behavior on mobile/tablet sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)