### PR TITLE
feat: add sparkline tooltips to Category Breakdown chart

### DIFF
--- a/.workflow-state.json
+++ b/.workflow-state.json
@@ -1,69 +1,50 @@
 {
   "project_name": "denver-urban-pulse",
   "work_type": "feature",
-  "created_at": "2026-03-16T12:00:00Z",
+  "created_at": "2026-03-16T16:00:00Z",
   "current_step": 6,
   "current_step_name": "implementation",
-  "current_phase": 2,
+  "current_phase": 1,
   "history": [
     {
       "step": 1,
       "action": "completed",
-      "timestamp": "2026-03-16T12:00:00Z",
-      "details": "PRD for dashboard restructuring approved"
+      "timestamp": "2026-03-16T16:00:00Z",
+      "details": "PRD for category sparkline tooltips approved"
     },
     {
       "step": 2,
       "action": "completed",
-      "timestamp": "2026-03-16T12:05:00Z",
-      "details": "Design brief updated — sidebar removed, top header added"
+      "timestamp": "2026-03-16T16:02:00Z",
+      "details": "Design brief unchanged — existing styles cover the feature"
     },
     {
       "step": 3,
       "action": "completed",
-      "timestamp": "2026-03-16T12:10:00Z",
-      "details": "Phasing complete — 2 phases, starting Phase 1"
+      "timestamp": "2026-03-16T16:05:00Z",
+      "details": "Single phase — all requirements together"
     },
     {
       "step": 4,
       "action": "completed",
-      "timestamp": "2026-03-16T12:15:00Z",
+      "timestamp": "2026-03-16T16:10:00Z",
       "details": "Phase 1 plan approved — 5 tasks"
     },
     {
       "step": 5,
       "action": "completed",
-      "timestamp": "2026-03-16T12:20:00Z",
-      "details": "Issues #127-#131 created, added to project board #13"
-    },
-    {
-      "step": 7,
-      "action": "completed",
-      "timestamp": "2026-03-16T14:00:00Z",
-      "details": "Phase 1 complete — PRs #132-#136 merged"
-    },
-    {
-      "step": 4,
-      "action": "completed",
-      "timestamp": "2026-03-16T14:10:00Z",
-      "details": "Phase 2 plan approved — 5 tasks"
-    },
-    {
-      "step": 5,
-      "action": "completed",
-      "timestamp": "2026-03-16T14:15:00Z",
-      "details": "Issues #137-#141 created, added to project board #13"
+      "timestamp": "2026-03-16T16:15:00Z",
+      "details": "Issues #155-#159 created, added to project board #13"
     }
   ],
   "artifacts": {
-    "prd_file": "docs/prd-dashboard-restructuring.md",
+    "prd_file": "docs/prd-category-sparkline-tooltips.md",
     "design_brief_file": "docs/design-brief.md",
     "plan_files": [
-      "docs/plans/2026-03-16-phase-1-layout-restructuring.md",
-      "docs/plans/2026-03-16-phase-2-chart-improvements-cleanup.md"
+      "docs/plans/2026-03-16-phase-1-category-sparkline-tooltips.md"
     ],
-    "issue_numbers": [127, 128, 129, 130, 131, 137, 138, 139, 140, 141],
-    "pr_numbers": [132, 133, 134, 135, 136],
+    "issue_numbers": [155, 156, 157, 158, 159],
+    "pr_numbers": [],
     "project_board_number": 13
   }
 }

--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -36,6 +36,8 @@ const { GET: getHeatmap } = require("@/app/api/city-pulse/heatmap/route");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { GET: getNeighborhoods } = require("@/app/api/city-pulse/neighborhoods/route");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET: getCategoryTrends } = require("@/app/api/city-pulse/category-trends/route");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { NextRequest } = require("next/server");
 
 function makeRequest(url: string) {
@@ -158,6 +160,40 @@ describe("City Pulse API", () => {
       expect(res.status).toBe(200);
       expect(body.data[0].neighborhood).toBe("Five Points");
       expect(body.data[0].crimeCount).toBe(80);
+    });
+  });
+
+  describe("GET /api/city-pulse/category-trends", () => {
+    it("groups trend rows by domain and category", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", category: "Theft", date: "2026-03-10", count: 12 },
+        { domain: "crime", category: "Theft", date: "2026-03-11", count: 15 },
+        { domain: "crime", category: "Assault", date: "2026-03-10", count: 5 },
+        { domain: "311", category: "Graffiti", date: "2026-03-10", count: 8 },
+      ]);
+
+      const res = await getCategoryTrends(
+        makeRequest("http://localhost/api/city-pulse/category-trends?timeWindow=7d")
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.crime.Theft).toHaveLength(2);
+      expect(body.data.crime.Theft[0]).toEqual({ date: "2026-03-10", value: 12 });
+      expect(body.data.crime.Assault).toHaveLength(1);
+      expect(body.data.requests311.Graffiti).toHaveLength(1);
+    });
+
+    it("returns 500 on error", async () => {
+      mockQuery.mockRejectedValueOnce(new Error("DB connection failed"));
+
+      const res = await getCategoryTrends(
+        makeRequest("http://localhost/api/city-pulse/category-trends?timeWindow=30d")
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe("DB connection failed");
     });
   });
 

--- a/__tests__/charts.test.tsx
+++ b/__tests__/charts.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { CategoryChart } from "@/components/charts/category-chart";
 import { HeatmapChart } from "@/components/charts/heatmap-chart";
-import type { CategoryBreakdown, HeatmapCell } from "@/lib/types";
+import type { CategoryBreakdown, CategoryTrends, HeatmapCell } from "@/lib/types";
 
 // Mock recharts to avoid canvas issues in jsdom
 jest.mock("recharts", () => ({
@@ -9,6 +9,10 @@ jest.mock("recharts", () => ({
     <div data-testid="line-chart">{children}</div>
   ),
   Line: () => <div />,
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  ),
+  Area: () => <div />,
   BarChart: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="bar-chart">{children}</div>
   ),
@@ -47,6 +51,39 @@ describe("CategoryChart", () => {
   it("shows empty message for no data", () => {
     render(<CategoryChart data={{}} />);
     expect(screen.getByText("No category data available")).toBeInTheDocument();
+  });
+
+  it("shows tooltip with sparkline on hover", () => {
+    const trends: CategoryTrends = {
+      crime: {
+        Theft: [
+          { date: "2026-03-10", value: 12 },
+          { date: "2026-03-11", value: 15 },
+        ],
+      },
+    };
+    render(<CategoryChart data={sampleCategories} trends={trends} />);
+
+    // Hover over the Theft bar row
+    const theftLabel = screen.getByText("Theft");
+    const barRow = theftLabel.closest("[class*='flex']")!;
+    fireEvent.mouseEnter(barRow);
+
+    // Tooltip should render — check for the tooltip container
+    const tooltipContainer = document.querySelector(".animate-fade-in");
+    expect(tooltipContainer).toBeInTheDocument();
+
+    // Tooltip should contain category name, count, and percent
+    expect(tooltipContainer!.textContent).toContain("Theft");
+    expect(tooltipContainer!.textContent).toContain("500");
+    expect(tooltipContainer!.textContent).toContain("40.0%");
+
+    // Sparkline should render (mocked as area-chart)
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+
+    // Mouse leave hides tooltip
+    fireEvent.mouseLeave(barRow);
+    expect(document.querySelector(".animate-fade-in")).not.toBeInTheDocument();
   });
 
   it("shows summary line for single-category domain", () => {

--- a/app/api/city-pulse/category-trends/route.ts
+++ b/app/api/city-pulse/category-trends/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCategoryTrends } from "@/lib/queries/city-pulse";
+import type { TimeWindow, ChartPoint } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
+    const rows = await getCategoryTrends(tw);
+
+    // Group: domain → category → ChartPoint[]
+    const grouped: Record<string, Record<string, ChartPoint[]>> = {};
+
+    for (const r of rows) {
+      const key = r.domain === "311" ? "requests311" : r.domain;
+      if (!grouped[key]) grouped[key] = {};
+      if (!grouped[key][r.category]) grouped[key][r.category] = [];
+      grouped[key][r.category].push({ date: r.date, value: r.count });
+    }
+
+    return NextResponse.json({
+      data: grouped,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -121,6 +121,15 @@
   }
 }
 
+/* Category tooltip fade-in */
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(-100%) translateY(4px); }
+  to { opacity: 1; transform: translateY(-100%); }
+}
+.animate-fade-in {
+  animation: fade-in 150ms ease-out forwards;
+}
+
 /* Leaflet tooltip overrides */
 .leaflet-tooltip-custom {
   background: white;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ import geojson from "@/data/geo/denver-neighborhoods.json";
 
 function CityPulseContent() {
   const { timeWindow, neighborhood } = useFilters();
-  const { kpis, categories, heatmap, neighborhoods, loading, error, retry, effectiveThrough, lastUpdated } =
+  const { kpis, categories, categoryTrends, heatmap, neighborhoods, loading, error, retry, effectiveThrough, lastUpdated } =
     useCityPulseData(timeWindow, neighborhood);
   const { aqi, comparison, loading: envLoading, error: envError, retry: envRetry, effectiveThrough: envEffectiveThrough } =
     useEnvironmentData(timeWindow, neighborhood);
@@ -120,7 +120,7 @@ function CityPulseContent() {
         </div>
         <div className="lg:col-span-5">
           <ChartCard title="Category Breakdown" loading={loading} className="h-full">
-            <CategoryChart data={categories} />
+            <CategoryChart data={categories} trends={categoryTrends} />
           </ChartCard>
         </div>
       </div>

--- a/components/charts/category-chart.tsx
+++ b/components/charts/category-chart.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import type { CategoryBreakdown } from "@/lib/types";
+import { useState, useRef, useCallback } from "react";
+import type { CategoryBreakdown, CategoryTrends, ChartPoint } from "@/lib/types";
 import { formatNumber } from "@/lib/format";
+import { Sparkline } from "@/components/ui/sparkline";
 
 interface CategoryChartProps {
   data: Record<string, CategoryBreakdown[]>;
+  trends?: CategoryTrends;
+}
+
+interface TooltipState {
+  domain: string;
+  color: string;
+  category: string;
+  count: number;
+  percent: number;
+  sparkline: ChartPoint[];
+  x: number;
+  y: number;
 }
 
 const DOMAINS = [
@@ -13,7 +27,39 @@ const DOMAINS = [
   { key: "requests311", label: "311 Requests", color: "#198754" },
 ];
 
-export function CategoryChart({ data }: CategoryChartProps) {
+export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseEnter = useCallback(
+    (
+      e: React.MouseEvent,
+      domain: { key: string; color: string },
+      item: CategoryBreakdown
+    ) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+
+      setTooltip({
+        domain: domain.key,
+        color: domain.color,
+        category: item.category,
+        count: item.count,
+        percent: item.percent,
+        sparkline: trends[domain.key]?.[item.category] ?? [],
+        x: targetRect.left - containerRect.left + targetRect.width / 2,
+        y: targetRect.top - containerRect.top,
+      });
+    },
+    [trends]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    setTooltip(null);
+  }, []);
+
   const hasDomains = DOMAINS.some((d) => data[d.key]?.length);
 
   if (!hasDomains) {
@@ -25,7 +71,7 @@ export function CategoryChart({ data }: CategoryChartProps) {
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3 relative" ref={containerRef}>
       {DOMAINS.map((domain) => {
         const items = data[domain.key];
         if (!items?.length) return null;
@@ -57,7 +103,12 @@ export function CategoryChart({ data }: CategoryChartProps) {
             </p>
             <div className="space-y-1">
               {items.slice(0, 6).map((item) => (
-                <div key={item.category} className="flex items-center gap-2">
+                <div
+                  key={item.category}
+                  className="flex items-center gap-2 cursor-default"
+                  onMouseEnter={(e) => handleMouseEnter(e, domain, item)}
+                  onMouseLeave={handleMouseLeave}
+                >
                   <span className="text-[9px] text-[#52667A] w-24 truncate shrink-0 text-right" title={item.category}>
                     {item.category}
                   </span>
@@ -83,6 +134,37 @@ export function CategoryChart({ data }: CategoryChartProps) {
           </div>
         );
       })}
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="absolute z-50 pointer-events-none animate-fade-in"
+          style={{
+            left: `clamp(0px, ${tooltip.x}px - 100px, calc(100% - 200px))`,
+            top: `${tooltip.y - 8}px`,
+            transform: "translateY(-100%)",
+          }}
+        >
+          <div className="bg-[#102A43] text-white rounded-lg shadow-lg px-3 py-2.5 w-[200px]">
+            <p className="text-[11px] font-medium leading-tight mb-1">
+              {tooltip.category}
+            </p>
+            <div className="flex items-center gap-2 text-[10px] text-white/70 mb-2">
+              <span>{formatNumber(tooltip.count)}</span>
+              <span className="text-white/40">·</span>
+              <span>{tooltip.percent.toFixed(1)}%</span>
+            </div>
+            {tooltip.sparkline.length > 1 && (
+              <Sparkline
+                data={tooltip.sparkline}
+                color={tooltip.color}
+                height={40}
+                interactive={false}
+              />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/plans/2026-03-16-phase-1-category-sparkline-tooltips.md
+++ b/docs/plans/2026-03-16-phase-1-category-sparkline-tooltips.md
@@ -1,0 +1,60 @@
+# Phase 1: Category Sparkline Tooltips
+
+## Overview
+Add per-category trend sparklines shown in tooltips on hover over Category Breakdown bars.
+
+## Tasks
+
+### Task 1: DB query for category trends
+**Description:** Add `getCategoryTrends(tw)` query function to `lib/queries/city-pulse.ts`. Queries `mart_incident_trends` for daily counts grouped by domain + category, filtered by time window. For 90d, aggregate by week (matching KPI sparkline pattern).
+**Files:** `lib/queries/city-pulse.ts`
+**Acceptance criteria:**
+- Returns `{ domain, category, date, count }[]` rows
+- Filters by time window (7d/30d daily, 90d weekly)
+- Ordered by domain, category, date ASC
+
+### Task 2: API endpoint for category trends
+**Description:** Create `/api/city-pulse/category-trends` route. Accepts `timeWindow` param. Calls `getCategoryTrends()`, groups results into `Record<string, Record<string, ChartPoint[]>>` (domain → category → sparkline points).
+**Files:** `app/api/city-pulse/category-trends/route.ts`
+**Acceptance criteria:**
+- GET endpoint returns `{ data: { crime: { "Vehicle Theft": [...], ... }, crashes: {...}, requests311: {...} } }`
+- Each sparkline is `ChartPoint[]` (date + value)
+- Handles errors with 500 response
+
+### Task 3: Extend hook to preload category trends
+**Description:** Add `categoryTrends` to `useCityPulseData` hook. Fetch `/api/city-pulse/category-trends` in parallel with existing requests. Add `CategoryTrends` type to `lib/types.ts`.
+**Files:** `lib/types.ts`, `lib/hooks/use-city-pulse-data.ts`
+**Acceptance criteria:**
+- `categoryTrends: Record<string, Record<string, ChartPoint[]>>` available in hook result
+- Fetched in parallel with categories, heatmap, neighborhoods
+- Empty object `{}` as default/fallback
+
+### Task 4: CategoryTooltip component + hover logic in CategoryChart
+**Description:** Create `CategoryTooltip` component showing full category name, formatted count, percentage, and a non-interactive `<Sparkline />` (height 40px). Add hover state (mouse enter/leave) to CategoryChart bar rows. Tooltip positioned above the hovered bar, clamped to viewport. Fade-in transition via CSS.
+**Files:** `components/charts/category-chart.tsx` (tooltip inline or separate component)
+**Acceptance criteria:**
+- Tooltip appears on hover with: category name, count, percent, sparkline
+- Sparkline colored by domain (blue/orange/green)
+- Tooltip stays within viewport bounds
+- Smooth fade-in transition
+- Tooltip hides on mouse leave
+
+### Task 5: Tests
+**Description:** Add tests for the new API endpoint and CategoryChart tooltip behavior.
+**Files:** `__tests__/category-trends-api.test.ts`, `__tests__/charts.test.tsx`
+**Acceptance criteria:**
+- API route test: correct grouping of trend data
+- CategoryChart test: tooltip renders on hover with expected content
+- Existing CategoryChart tests still pass
+
+## Dependency order
+```
+Task 1 → Task 2 → Task 3 → Task 4 → Task 5
+```
+All tasks are sequential — each builds on the previous.
+
+## Verification
+- `npm run lint` passes
+- `npm run build` passes
+- `npm test` passes
+- Manual verification: hover over bars on dev server, tooltips with sparklines appear

--- a/docs/prd-category-sparkline-tooltips.md
+++ b/docs/prd-category-sparkline-tooltips.md
@@ -1,0 +1,74 @@
+# PRD: Category Breakdown Sparkline Tooltips
+
+## Metadata
+| Field | Value |
+|-------|-------|
+| Author | Dmitry Vasichev |
+| Date | 2026-03-16 |
+| Status | Approved |
+| Priority | P1 |
+
+## Overview
+Add rich hover tooltips to the Category Breakdown bar chart. When a user hovers over a category bar, a tooltip appears showing the full category name, count, percentage, and an embedded sparkline chart showing the daily trend for that category over the selected time window. This fills a gap — the dashboard currently shows total trends via KPI cards but has no per-category trend visibility.
+
+## User Scenarios
+### Scenario 1: Exploring category trends
+**As a** dashboard viewer, **I want to** hover over a category bar and instantly see its daily trend, **so that** I can understand whether that category is rising, falling, or stable — without navigating away from the overview.
+
+## Functional Requirements
+
+### P0 (Must Have)
+- [ ] FR-1: New API endpoint to return daily sparkline data for all displayed categories (batch), grouped by domain
+- [ ] FR-2: Query `mart_incident_trends` table filtered by time window, domain, and top-N categories
+- [ ] FR-3: Preload sparkline data for all visible categories when the Category Breakdown card loads (no lazy loading)
+- [ ] FR-4: Custom tooltip component appearing on bar hover, containing:
+  - Full category name (no truncation)
+  - Count (formatted)
+  - Percentage
+  - Sparkline chart (reusing existing `<Sparkline />` component) colored by domain
+- [ ] FR-5: Tooltip positioned near the hovered bar, staying within viewport bounds
+
+### P1 (Should Have)
+- [ ] FR-6: Smooth tooltip appearance (fade-in transition)
+
+## Out of Scope
+- Click-to-drill-down into a category detail view
+- Neighborhood filtering on sparkline data
+- Sparkline interactivity within the tooltip (no hover-on-sparkline)
+
+## Technical Notes
+
+### Existing infrastructure to reuse
+- **Data source:** `mart_incident_trends` table already stores daily counts per (date, domain, category)
+- **Sparkline component:** `components/ui/sparkline.tsx` — accepts `ChartPoint[]`, renders Recharts AreaChart
+- **Types:** `ChartPoint { date: string; value: number }`, `CategoryBreakdown { category, count, percent }`
+
+### New API endpoint
+- `GET /api/city-pulse/category-trends?timeWindow=7d&neighborhood=all`
+- Returns: `Record<string, Record<string, ChartPoint[]>>` — keyed by domain, then by category
+- Query: select from `mart_incident_trends` where date within time window, for categories present in current breakdown
+
+### Frontend changes
+- Extend `useCityPulseData` hook to fetch category trends alongside existing data
+- Add `CategoryTooltip` component with sparkline embedded (non-interactive sparkline, height ~40px)
+- Add hover state management to `CategoryChart` (mouse enter/leave on bar rows)
+- Tooltip positioning via CSS absolute/fixed positioning
+
+### Data flow
+```
+mart_incident_trends (DB)
+  → /api/city-pulse/category-trends (API)
+    → useCityPulseData hook (preloaded)
+      → CategoryChart receives trends as prop
+        → hover bar → show CategoryTooltip with sparkline
+```
+
+## Implementation Phases
+
+### Phase 1: Category Sparkline Tooltips (single phase)
+All requirements (FR-1 through FR-6) implemented together:
+1. API endpoint + DB query for per-category daily trends
+2. Frontend data fetching (preloaded in hook)
+3. Custom tooltip component with embedded sparkline
+4. Tooltip positioning and transitions
+5. Tests

--- a/lib/hooks/use-city-pulse-data.ts
+++ b/lib/hooks/use-city-pulse-data.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import type {
   KpiData,
   CategoryBreakdown,
+  CategoryTrends,
   HeatmapCell,
   NeighborhoodRow,
   TimeWindow,
@@ -12,6 +13,7 @@ import type {
 interface CityPulseData {
   kpis: { crime: KpiData; crashes: KpiData; requests311: KpiData } | null;
   categories: Record<string, CategoryBreakdown[]>;
+  categoryTrends: CategoryTrends;
   heatmap: HeatmapCell[];
   neighborhoods: NeighborhoodRow[];
   effectiveThrough: string | null;
@@ -36,6 +38,7 @@ export function useCityPulseData(
   const [data, setData] = useState<Omit<CityPulseData, "retry">>({
     kpis: null,
     categories: {},
+    categoryTrends: {},
     heatmap: [],
     neighborhoods: [],
     effectiveThrough: null,
@@ -56,9 +59,12 @@ export function useCityPulseData(
         return r.json();
       });
 
-      const [categories, heatmap, neighborhoods] = await Promise.all([
+      const [categories, categoryTrends, heatmap, neighborhoods] = await Promise.all([
         fetchJson<Record<string, CategoryBreakdown[]>>(
           `/api/city-pulse/categories?${qs}`
+        ),
+        fetchJson<CategoryTrends>(
+          `/api/city-pulse/category-trends?timeWindow=${timeWindow}`
         ),
         fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?${qs}`),
         fetchJson<NeighborhoodRow[]>(
@@ -69,6 +75,7 @@ export function useCityPulseData(
       setData({
         kpis: kpisResp.data,
         categories,
+        categoryTrends,
         heatmap,
         neighborhoods,
         effectiveThrough: kpisResp.effectiveThrough ?? null,

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -198,6 +198,43 @@ export async function getEffectiveThrough(tw: TimeWindow): Promise<string | null
   return rows[0]?.effective_through ?? null;
 }
 
+// --- Category Trends (sparklines per category) ---
+
+interface CategoryTrendRow {
+  domain: string;
+  category: string;
+  date: string;
+  count: number;
+}
+
+export async function getCategoryTrends(
+  tw: TimeWindow
+): Promise<CategoryTrendRow[]> {
+  const days = daysForWindow(tw);
+  if (days <= 30) {
+    return query<CategoryTrendRow>(
+      `SELECT domain, category, date::text, count
+       FROM mart_incident_trends
+       WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+       ORDER BY domain, category, date`,
+      [days]
+    );
+  }
+  // 90d: aggregate by week for cleaner sparklines
+  return query<CategoryTrendRow>(
+    `SELECT domain, category,
+            DATE_TRUNC('week', date)::date::text AS date,
+            SUM(count)::int AS count
+     FROM mart_incident_trends
+     WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+       AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+     GROUP BY domain, category, DATE_TRUNC('week', date)
+     ORDER BY domain, category, date`,
+    [days]
+  );
+}
+
 // --- Categories ---
 
 interface CategoryRow {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,6 +58,8 @@ export interface CategoryBreakdown {
   percent: number;
 }
 
+export type CategoryTrends = Record<string, Record<string, ChartPoint[]>>;
+
 export interface HeatmapCell {
   dayOfWeek: number;
   hourOfDay: number;


### PR DESCRIPTION
## Summary
- Add rich hover tooltips to Category Breakdown bar chart with embedded sparkline showing per-category daily trends
- New API endpoint `/api/city-pulse/category-trends` querying `mart_incident_trends` for daily counts by domain + category
- Preload sparkline data for all visible categories in `useCityPulseData` hook (no lazy loading)
- Custom tooltip with full category name, formatted count, percentage, and non-interactive sparkline colored by domain
- Viewport-aware positioning and fade-in transition

Closes #155, closes #156, closes #157, closes #158, closes #159

## Test plan
- [x] API route test: correct grouping of trend data by domain/category
- [x] API route test: 500 on DB error
- [x] CategoryChart test: tooltip renders on hover with expected content
- [x] CategoryChart test: tooltip hides on mouse leave
- [x] Existing CategoryChart tests still pass
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes (75 passing)
- [ ] Manual: hover over bars on dev server, tooltips with sparklines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)