### PR TITLE
Fix: sparkline not visible in Category Breakdown tooltip

### DIFF
--- a/__tests__/charts.test.tsx
+++ b/__tests__/charts.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CategoryChart } from "@/components/charts/category-chart";
 import { HeatmapChart } from "@/components/charts/heatmap-chart";
+import { Sparkline } from "@/components/ui/sparkline";
 import type { CategoryBreakdown, CategoryTrends, HeatmapCell } from "@/lib/types";
 
 // Mock recharts to avoid canvas issues in jsdom
@@ -98,6 +99,31 @@ describe("CategoryChart", () => {
     expect(screen.getByText("500")).toBeInTheDocument();
     // Should not render bar for single-category domain
     expect(screen.queryByText("Larceny")).not.toBeInTheDocument();
+  });
+});
+
+describe("Sparkline regression: numeric width bypasses ResponsiveContainer", () => {
+  const trendData = [
+    { date: "2026-03-10", value: 10 },
+    { date: "2026-03-11", value: 20 },
+  ];
+
+  it("renders AreaChart directly when width is a number (tooltip context)", () => {
+    const { container } = render(
+      <Sparkline data={trendData} color="#2458C6" width={176} height={40} interactive={false} />
+    );
+    // AreaChart should render (mocked as area-chart testid)
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+    // Should NOT have ResponsiveContainer wrapper (no extra nesting)
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.width).toBe("176px");
+  });
+
+  it("uses ResponsiveContainer when width is a string", () => {
+    render(
+      <Sparkline data={trendData} color="#2458C6" width="100%" height={40} interactive={false} />
+    );
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
   });
 });
 

--- a/components/charts/category-chart.tsx
+++ b/components/charts/category-chart.tsx
@@ -158,6 +158,7 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
               <Sparkline
                 data={tooltip.sparkline}
                 color={tooltip.color}
+                width={176}
                 height={40}
                 interactive={false}
               />

--- a/components/ui/sparkline.tsx
+++ b/components/ui/sparkline.tsx
@@ -44,41 +44,55 @@ export function Sparkline({
 
   if (data.length === 0) return null;
 
+  const numericWidth = typeof width === "number" ? width : undefined;
+
+  const chart = (
+    <AreaChart
+      data={data}
+      width={numericWidth}
+      height={numericWidth ? height : undefined}
+      margin={{ top: 2, right: 2, bottom: 0, left: 2 }}
+    >
+      <defs>
+        <linearGradient id={`spark-${color}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.3} />
+          <stop offset="100%" stopColor={color} stopOpacity={0.05} />
+        </linearGradient>
+      </defs>
+      {interactive && (
+        <Tooltip
+          content={renderTooltip}
+          cursor={{ stroke: color, strokeOpacity: 0.3, strokeWidth: 1 }}
+          isAnimationActive={false}
+        />
+      )}
+      <Area
+        type="monotone"
+        dataKey="value"
+        stroke={color}
+        strokeWidth={1.5}
+        fill={`url(#spark-${color})`}
+        isAnimationActive={false}
+        activeDot={{
+          r: 3,
+          fill: color,
+          stroke: "#fff",
+          strokeWidth: 1.5,
+        }}
+      />
+    </AreaChart>
+  );
+
+  // When width is a fixed number, render AreaChart directly — ResponsiveContainer
+  // fails inside CSS-transformed / pointer-events-none containers (e.g. tooltips).
+  if (numericWidth) {
+    return <div style={{ width, height }}>{chart}</div>;
+  }
+
   return (
     <div style={{ width, height }}>
       <ResponsiveContainer width="100%" height="100%">
-        <AreaChart
-          data={data}
-          margin={{ top: 2, right: 2, bottom: 0, left: 2 }}
-        >
-          <defs>
-            <linearGradient id={`spark-${color}`} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={color} stopOpacity={0.3} />
-              <stop offset="100%" stopColor={color} stopOpacity={0.05} />
-            </linearGradient>
-          </defs>
-          {interactive && (
-            <Tooltip
-              content={renderTooltip}
-              cursor={{ stroke: color, strokeOpacity: 0.3, strokeWidth: 1 }}
-              isAnimationActive={false}
-            />
-          )}
-          <Area
-            type="monotone"
-            dataKey="value"
-            stroke={color}
-            strokeWidth={1.5}
-            fill={`url(#spark-${color})`}
-            isAnimationActive={false}
-            activeDot={{
-              r: 3,
-              fill: color,
-              stroke: "#fff",
-              strokeWidth: 1.5,
-            }}
-          />
-        </AreaChart>
+        {chart}
       </ResponsiveContainer>
     </div>
   );


### PR DESCRIPTION
## Summary
- Sparkline chart was invisible inside Category Breakdown tooltip due to Recharts `ResponsiveContainer` failing to measure dimensions inside a CSS-transformed, `pointer-events-none` container
- When `Sparkline` receives a numeric `width`, it now renders `AreaChart` directly with fixed dimensions, bypassing `ResponsiveContainer`
- Passed explicit `width={176}` from the tooltip context (200px card minus 24px padding)

Closes #161

## Test plan
- [x] Regression test: Sparkline with numeric width renders without ResponsiveContainer
- [x] Existing tooltip hover test still passes
- [x] Lint + build + all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)