### PR TITLE
Fix: align category labels so sparkline tooltips render

### DIFF
--- a/data/marts/build_incident_trends.py
+++ b/data/marts/build_incident_trends.py
@@ -1,7 +1,8 @@
 """
 Build mart_incident_trends — daily counts by domain + category.
 
-Crime by offense_category, crashes by top_offense, 311 by request_type.
+Crime by offense_category, crashes by top_offense, 311 by agency.
+Category labels match mart_category_breakdown for sparkline lookups.
 Uses UPSERT for idempotency.
 """
 
@@ -12,47 +13,74 @@ from db import count_rows, execute_sql, truncate_table
 
 logger = logging.getLogger(__name__)
 
+# Human-readable labels — must match build_category_breakdown.py exactly
+CRIME_LABEL_SQL = """
+    CASE COALESCE(offense_category, 'unknown')
+        WHEN 'all-other-crimes'        THEN 'Other'
+        WHEN 'theft-from-motor-vehicle' THEN 'Vehicle Theft'
+        WHEN 'white-collar-crime'       THEN 'White-Collar Crime'
+        WHEN 'murder'                   THEN 'Homicide'
+        ELSE INITCAP(REPLACE(COALESCE(offense_category, 'Unknown'), '-', ' '))
+    END
+"""
+
+CRASH_LABEL_SQL = """
+    CASE TRIM(COALESCE(top_offense, 'Unknown'))
+        WHEN 'TRAF - ACCIDENT'             THEN 'Traffic Accident'
+        WHEN 'TRAF - ACCIDENT - HIT & RUN' THEN 'Hit & Run'
+        WHEN 'TRAF - ACCIDENT - DUI/DUID'  THEN 'DUI / DUID'
+        WHEN 'TRAF - ACCIDENT - SBI'       THEN 'Serious Bodily Injury'
+        WHEN 'TRAF - ACCIDENT - POLICE'    THEN 'Police Involved'
+        WHEN 'TRAF - ACCIDENT - FATAL'     THEN 'Fatal Crash'
+        WHEN 'TRAF - HABITUAL OFFENDER'    THEN 'Habitual Offender'
+        ELSE INITCAP(REPLACE(
+            REPLACE(TRIM(COALESCE(top_offense, 'Unknown')), 'TRAF - ACCIDENT - ', ''),
+            '-', ' '
+        ))
+    END
+"""
+
 BUILD_SQL = """
 INSERT INTO mart_incident_trends (date, domain, category, count, updated_at)
 
--- Crime by offense_category
+-- Crime by offense_category (human-readable labels)
 SELECT
     (reported_date AT TIME ZONE 'America/Denver')::date AS date,
     'crime' AS domain,
-    COALESCE(offense_category, 'Unknown') AS category,
+    {crime_label} AS category,
     COUNT(*) AS count,
     NOW()
 FROM stg_crime
-GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, offense_category
+GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, {crime_label}
 
 UNION ALL
 
--- Crashes by top_offense
+-- Crashes by top_offense (human-readable labels)
 SELECT
     (reported_date AT TIME ZONE 'America/Denver')::date AS date,
     'crashes' AS domain,
-    COALESCE(top_offense, 'Unknown') AS category,
+    {crash_label} AS category,
     COUNT(*) AS count,
     NOW()
 FROM stg_crashes
-GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, top_offense
+GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, {crash_label}
 
 UNION ALL
 
--- 311 by request_type
+-- 311 by agency (matches mart_category_breakdown)
 SELECT
     (case_created_date AT TIME ZONE 'America/Denver')::date AS date,
     '311' AS domain,
-    COALESCE(request_type, 'Unknown') AS category,
+    COALESCE(NULLIF(agency, ''), 'Other') AS category,
     COUNT(*) AS count,
     NOW()
 FROM stg_311
-GROUP BY (case_created_date AT TIME ZONE 'America/Denver')::date, request_type
+GROUP BY (case_created_date AT TIME ZONE 'America/Denver')::date, agency
 
 ON CONFLICT (date, domain, category) DO UPDATE SET
     count = EXCLUDED.count,
     updated_at = NOW()
-"""
+""".format(crime_label=CRIME_LABEL_SQL, crash_label=CRASH_LABEL_SQL)
 
 
 def build() -> dict:

--- a/data/marts/tests/test_build_daily.py
+++ b/data/marts/tests/test_build_daily.py
@@ -7,7 +7,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "staging"
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from build_city_pulse_daily import BUILD_SQL as DAILY_SQL
-from build_incident_trends import BUILD_SQL as TRENDS_SQL
+from build_incident_trends import BUILD_SQL as TRENDS_SQL, CRIME_LABEL_SQL as TRENDS_CRIME_LABEL, CRASH_LABEL_SQL as TRENDS_CRASH_LABEL
+from build_category_breakdown import CRIME_LABEL_SQL as BREAKDOWN_CRIME_LABEL, CRASH_LABEL_SQL as BREAKDOWN_CRASH_LABEL
 from build_aqi_daily import BUILD_SQL as AQI_SQL
 
 
@@ -57,8 +58,22 @@ class TestIncidentTrendsSQL:
     def test_uses_top_offense_for_crashes(self):
         assert "top_offense" in TRENDS_SQL
 
-    def test_uses_request_type_for_311(self):
-        assert "request_type" in TRENDS_SQL
+    def test_uses_agency_for_311(self):
+        assert "agency" in TRENDS_SQL
+
+    def test_uses_human_readable_crime_labels(self):
+        assert "Vehicle Theft" in TRENDS_SQL
+        assert "INITCAP" in TRENDS_SQL
+
+    def test_uses_human_readable_crash_labels(self):
+        assert "Traffic Accident" in TRENDS_SQL
+        assert "Hit & Run" in TRENDS_SQL
+
+    def test_crime_labels_match_category_breakdown(self):
+        assert TRENDS_CRIME_LABEL.strip() == BREAKDOWN_CRIME_LABEL.strip()
+
+    def test_crash_labels_match_category_breakdown(self):
+        assert TRENDS_CRASH_LABEL.strip() == BREAKDOWN_CRASH_LABEL.strip()
 
 
 class TestAqiDailySQL:


### PR DESCRIPTION
## Summary
- **Root cause:** `mart_incident_trends` stored raw slugs (`theft-from-motor-vehicle`, `TRAF - ACCIDENT`) while `mart_category_breakdown` stored human-readable labels (`Vehicle Theft`, `Traffic Accident`). The tooltip lookup `trends[domain][category]` always returned `undefined` → empty sparkline array → chart never rendered.
- Applied the same CASE label transformations from `build_category_breakdown.py` to `build_incident_trends.py`
- Switched 311 domain from `request_type` to `agency` to match breakdown table
- Added regression tests ensuring label SQL expressions stay in sync between both mart builders

Closes #163
Supersedes #162 (which addressed ResponsiveContainer — a non-issue)

## Post-merge action
**Re-run the daily pipeline** to rebuild `mart_incident_trends` with corrected labels:
```bash
railway run python data/pipeline/run_daily.py
```

## Test plan
- [x] `test_crime_labels_match_category_breakdown` — labels identical between builders
- [x] `test_crash_labels_match_category_breakdown` — labels identical between builders
- [x] `test_uses_agency_for_311` — uses agency instead of request_type
- [x] `test_uses_human_readable_crime_labels` / `test_uses_human_readable_crash_labels`
- [x] All 24 mart SQL tests pass, all 77 JS tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)