### PR TITLE
Fix: Dockerfile paths for Railway build context

### DIFF
--- a/data/pipeline/Dockerfile
+++ b/data/pipeline/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install dependencies
-COPY requirements.txt .
+# Install dependencies (paths relative to repo root — Railway build context)
+COPY data/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy all data scripts
-COPY . .
+COPY data/ ./data/
 
-CMD ["python", "pipeline/run_daily.py"]
+CMD ["python", "data/pipeline/run_daily.py"]


### PR DESCRIPTION
## Summary
- Railway uses repo root as Docker build context when Dockerfile path is `data/pipeline/Dockerfile`
- Updated `COPY` paths from relative (`requirements.txt`, `. .`) to repo-root-relative (`data/requirements.txt`, `data/ ./data/`)
- Updated `CMD` from `pipeline/run_daily.py` to `data/pipeline/run_daily.py`

Follow-up to #164 — needed for daily pipeline cron service on Railway.

## Test plan
- [x] Lint + tests pass
- [ ] Railway Dockerfile build succeeds (verify after merge + deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)