### PR TITLE
Fix: evenly space AQI Trend X-axis labels

### DIFF
--- a/__tests__/charts-environment.test.tsx
+++ b/__tests__/charts-environment.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { AqiTrendChart } from "@/components/charts/aqi-trend-chart";
+import { AqiTrendChart, evenlySpacedTicks } from "@/components/charts/aqi-trend-chart";
 import { ChangeLeadersChart, computeLeaders } from "@/components/charts/change-leaders-chart";
 import type { AqiDailyPoint, ComparisonRow } from "@/lib/types";
 
@@ -41,6 +41,35 @@ describe("AqiTrendChart", () => {
   it("shows empty message for no data", () => {
     render(<AqiTrendChart data={[]} />);
     expect(screen.getByText("No AQI data available")).toBeInTheDocument();
+  });
+
+  describe("evenlySpacedTicks", () => {
+    it("returns all dates when data fits within maxTicks", () => {
+      const ticks = evenlySpacedTicks(sampleAqi, 5);
+      expect(ticks).toEqual(["2026-03-01", "2026-03-02", "2026-03-03"]);
+    });
+
+    it("returns evenly spaced ticks for 30-day dataset", () => {
+      const data: AqiDailyPoint[] = [];
+      const start = new Date("2026-02-14");
+      for (let i = 0; i < 30; i++) {
+        const dt = new Date(start);
+        dt.setDate(start.getDate() + i);
+        const iso = dt.toISOString().slice(0, 10);
+        data.push({ date: iso, aqiMax: 40, aqiOzone: 30, aqiPm25: 40, aqiPm10: 10, category: "Good" });
+      }
+
+      const ticks = evenlySpacedTicks(data, 5);
+      expect(ticks).toHaveLength(5);
+      expect(ticks[0]).toBe("2026-02-14");
+      expect(ticks[4]).toBe(data[data.length - 1].date);
+
+      // Verify even spacing: intervals between consecutive ticks should be equal
+      const indices = ticks.map((t) => data.findIndex((d) => d.date === t));
+      const gaps = indices.slice(1).map((idx, i) => idx - indices[i]);
+      const allEqual = gaps.every((g) => Math.abs(g - gaps[0]) <= 1);
+      expect(allEqual).toBe(true);
+    });
   });
 });
 

--- a/components/charts/aqi-trend-chart.tsx
+++ b/components/charts/aqi-trend-chart.tsx
@@ -59,6 +59,16 @@ function CustomTooltip({
   );
 }
 
+export function evenlySpacedTicks(data: AqiDailyPoint[], maxTicks = 5): string[] {
+  if (data.length <= maxTicks) return data.map((d) => d.date);
+  const ticks: string[] = [];
+  const step = (data.length - 1) / (maxTicks - 1);
+  for (let i = 0; i < maxTicks; i++) {
+    ticks.push(data[Math.round(i * step)].date);
+  }
+  return ticks;
+}
+
 export function AqiTrendChart({ data }: AqiTrendChartProps) {
   if (data.length === 0) {
     return (
@@ -67,6 +77,8 @@ export function AqiTrendChart({ data }: AqiTrendChartProps) {
       </div>
     );
   }
+
+  const ticks = evenlySpacedTicks(data);
 
   return (
     <ResponsiveContainer width="100%" height={220}>
@@ -91,11 +103,11 @@ export function AqiTrendChart({ data }: AqiTrendChartProps) {
         <CartesianGrid strokeDasharray="3 3" stroke="#EEF3F8" />
         <XAxis
           dataKey="date"
+          ticks={ticks}
           tickFormatter={formatDateShort}
           tick={{ fontSize: 10, fill: "#627D98" }}
           axisLine={{ stroke: "#DDE3EA" }}
           tickLine={false}
-          interval="preserveStartEnd"
         />
         <YAxis
           domain={[0, (max: number) => Math.max(max + 10, 100)]}


### PR DESCRIPTION
## Summary
- Replace `interval="preserveStartEnd"` with explicit evenly-spaced `ticks` array on the AQI Trend chart X-axis
- Add `evenlySpacedTicks()` helper that picks 5 equally distributed dates from the dataset
- Add regression test verifying tick count, boundaries, and even spacing

Closes #170

## Test plan
- [x] Regression test for `evenlySpacedTicks` with 30-day dataset
- [x] All existing tests pass (79 passed, 2 skipped)
- [x] Build succeeds
- [ ] Visual check: X-axis labels evenly distributed on Environment page

🤖 Generated with [Claude Code](https://claude.com/claude-code)