### PR TITLE
Fix: tooltip layout shift in Category Breakdown

### DIFF
--- a/components/cards/chart-card.tsx
+++ b/components/cards/chart-card.tsx
@@ -22,7 +22,7 @@ export function ChartCard({ title, children, insight, loading, className }: Char
   return (
     <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] flex flex-col ${className ?? ""}`}>
       <h3 className="text-xs font-bold text-[#102A43] mb-2 truncate">{title}</h3>
-      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1 flex flex-col min-h-0">{children}</div>
+      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1 flex flex-col min-h-0 overflow-hidden">{children}</div>
       {insight && (
         <p className="text-[10px] text-[#6B7B8D] mt-2 leading-tight">
           {insight}

--- a/components/charts/category-chart.tsx
+++ b/components/charts/category-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useCallback } from "react";
 import type { CategoryBreakdown, CategoryTrends, ChartPoint } from "@/lib/types";
 import { formatNumber } from "@/lib/format";
 import { Sparkline } from "@/components/ui/sparkline";
@@ -29,7 +29,6 @@ const DOMAINS = [
 
 export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleMouseEnter = useCallback(
     (
@@ -37,9 +36,6 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
       domain: { key: string; color: string },
       item: CategoryBreakdown
     ) => {
-      const container = containerRef.current;
-      if (!container) return;
-      const containerRect = container.getBoundingClientRect();
       const targetRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
 
       setTooltip({
@@ -49,8 +45,8 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
         count: item.count,
         percent: item.percent,
         sparkline: trends[domain.key]?.[item.category] ?? [],
-        x: targetRect.left - containerRect.left + targetRect.width / 2,
-        y: targetRect.top - containerRect.top,
+        x: targetRect.left + targetRect.width / 2,
+        y: targetRect.top,
       });
     },
     [trends]
@@ -71,7 +67,7 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
   }
 
   return (
-    <div className="space-y-3 relative" ref={containerRef}>
+    <div className="space-y-3">
       {DOMAINS.map((domain) => {
         const items = data[domain.key];
         if (!items?.length) return null;
@@ -138,9 +134,9 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="absolute z-50 pointer-events-none animate-fade-in"
+          className="fixed z-50 pointer-events-none animate-fade-in"
           style={{
-            left: `clamp(0px, ${tooltip.x}px - 100px, calc(100% - 200px))`,
+            left: `clamp(8px, ${tooltip.x - 100}px, calc(100vw - 208px))`,
             top: `${tooltip.y - 8}px`,
             transform: "translateY(-100%)",
           }}


### PR DESCRIPTION
Closes #172

## Summary
- Changed Category Breakdown tooltip from `position: absolute` to `position: fixed` (viewport-relative), so it no longer affects the container's scrollHeight and doesn't cause the grid row to recalculate height
- Added `overflow-hidden` to ChartCard content wrapper as additional protection against content overflow affecting flex calculations
- Removed unused `containerRef` since tooltip coordinates are now viewport-based

## Test plan
- [ ] Hover over bars in Category Breakdown — tooltip appears correctly above the bar
- [ ] Verify Neighborhood Map and Category Breakdown cards maintain stable height on hover
- [ ] Check tooltip stays within viewport bounds on edge categories
- [ ] Verify no visual regressions on mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)