### PR TITLE
Fix: render tooltip via React portal to prevent layout shift

### DIFF
--- a/components/cards/chart-card.tsx
+++ b/components/cards/chart-card.tsx
@@ -22,7 +22,7 @@ export function ChartCard({ title, children, insight, loading, className }: Char
   return (
     <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] flex flex-col ${className ?? ""}`}>
       <h3 className="text-xs font-bold text-[#102A43] mb-2 truncate">{title}</h3>
-      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1 flex flex-col min-h-0 overflow-hidden">{children}</div>
+      <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1 flex flex-col min-h-0">{children}</div>
       {insight && (
         <p className="text-[10px] text-[#6B7B8D] mt-2 leading-tight">
           {insight}

--- a/components/charts/category-chart.tsx
+++ b/components/charts/category-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { createPortal } from "react-dom";
 import type { CategoryBreakdown, CategoryTrends, ChartPoint } from "@/lib/types";
 import { formatNumber } from "@/lib/format";
 import { Sparkline } from "@/components/ui/sparkline";
@@ -67,72 +68,74 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
   }
 
   return (
-    <div className="space-y-3">
-      {DOMAINS.map((domain) => {
-        const items = data[domain.key];
-        if (!items?.length) return null;
+    <>
+      <div className="space-y-3">
+        {DOMAINS.map((domain) => {
+          const items = data[domain.key];
+          if (!items?.length) return null;
 
-        const maxCount = Math.max(...items.map((i) => i.count));
+          const maxCount = Math.max(...items.map((i) => i.count));
 
-        // If domain has only one category, show a summary line instead of a chart
-        if (items.length === 1) {
-          const item = items[0];
+          // If domain has only one category, show a summary line instead of a chart
+          if (items.length === 1) {
+            const item = items[0];
+            return (
+              <div key={domain.key}>
+                <p className="text-[10px] font-semibold text-[#102A43] mb-1.5">
+                  {domain.label}
+                </p>
+                <div className="flex items-center gap-2 px-1">
+                  <span className="text-[9px] text-[#52667A]">Total</span>
+                  <span className="text-[11px] font-medium text-[#102A43]">
+                    {formatNumber(item.count)}
+                  </span>
+                </div>
+              </div>
+            );
+          }
+
           return (
             <div key={domain.key}>
               <p className="text-[10px] font-semibold text-[#102A43] mb-1.5">
                 {domain.label}
               </p>
-              <div className="flex items-center gap-2 px-1">
-                <span className="text-[9px] text-[#52667A]">Total</span>
-                <span className="text-[11px] font-medium text-[#102A43]">
-                  {formatNumber(item.count)}
-                </span>
+              <div className="space-y-1">
+                {items.slice(0, 6).map((item) => (
+                  <div
+                    key={item.category}
+                    className="flex items-center gap-2 cursor-default"
+                    onMouseEnter={(e) => handleMouseEnter(e, domain, item)}
+                    onMouseLeave={handleMouseLeave}
+                  >
+                    <span className="text-[9px] text-[#52667A] w-24 truncate shrink-0 text-right" title={item.category}>
+                      {item.category}
+                    </span>
+                    <div className="flex-1 h-3.5 bg-[#EEF3F8] rounded-sm overflow-hidden">
+                      <div
+                        className="h-full rounded-sm transition-all"
+                        style={{
+                          width: `${(item.count / maxCount) * 100}%`,
+                          backgroundColor: domain.color,
+                          opacity: 0.8,
+                        }}
+                      />
+                    </div>
+                    <span className="text-[9px] text-[#627D98] w-12 shrink-0">
+                      {formatNumber(item.count)}
+                    </span>
+                    <span className="text-[9px] text-[#627D98] w-8 shrink-0">
+                      {item.percent.toFixed(0)}%
+                    </span>
+                  </div>
+                ))}
               </div>
             </div>
           );
-        }
+        })}
+      </div>
 
-        return (
-          <div key={domain.key}>
-            <p className="text-[10px] font-semibold text-[#102A43] mb-1.5">
-              {domain.label}
-            </p>
-            <div className="space-y-1">
-              {items.slice(0, 6).map((item) => (
-                <div
-                  key={item.category}
-                  className="flex items-center gap-2 cursor-default"
-                  onMouseEnter={(e) => handleMouseEnter(e, domain, item)}
-                  onMouseLeave={handleMouseLeave}
-                >
-                  <span className="text-[9px] text-[#52667A] w-24 truncate shrink-0 text-right" title={item.category}>
-                    {item.category}
-                  </span>
-                  <div className="flex-1 h-3.5 bg-[#EEF3F8] rounded-sm overflow-hidden">
-                    <div
-                      className="h-full rounded-sm transition-all"
-                      style={{
-                        width: `${(item.count / maxCount) * 100}%`,
-                        backgroundColor: domain.color,
-                        opacity: 0.8,
-                      }}
-                    />
-                  </div>
-                  <span className="text-[9px] text-[#627D98] w-12 shrink-0">
-                    {formatNumber(item.count)}
-                  </span>
-                  <span className="text-[9px] text-[#627D98] w-8 shrink-0">
-                    {item.percent.toFixed(0)}%
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        );
-      })}
-
-      {/* Tooltip */}
-      {tooltip && (
+      {/* Tooltip rendered via portal to avoid layout interference */}
+      {tooltip && createPortal(
         <div
           className="fixed z-50 pointer-events-none animate-fade-in"
           style={{
@@ -160,8 +163,9 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
               />
             )}
           </div>
-        </div>
+        </div>,
+        document.body
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #172

## Summary
- **Root cause**: tooltip was conditionally rendered as a child inside the `space-y-3` container. Adding/removing the DOM node triggered browser reflow — Tailwind's `space-y` margin selector (`> :not([hidden]) ~ :not([hidden])`) matched the tooltip child, and the flex/grid `items-stretch` layout recalculated row height for both cards.
- **Fix**: render the tooltip via `createPortal(…, document.body)` — completely outside the component's DOM tree. No DOM mutations inside the chart container on hover, zero layout impact.
- Reverts `overflow-hidden` from ChartCard (shared component, unnecessary with portal approach)

## Test plan
- [ ] Hover over bars in Category Breakdown — tooltip appears correctly above the bar
- [ ] Verify Neighborhood Map and Category Breakdown cards maintain stable height on hover
- [ ] Check tooltip stays within viewport bounds on edge categories
- [ ] Verify no visual regressions on mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)