### PR TITLE
Fix: unify tooltip styles to white background

### DIFF
--- a/components/charts/category-chart.tsx
+++ b/components/charts/category-chart.tsx
@@ -144,14 +144,17 @@ export function CategoryChart({ data, trends = {} }: CategoryChartProps) {
             transform: "translateY(-100%)",
           }}
         >
-          <div className="bg-[#102A43] text-white rounded-lg shadow-lg px-3 py-2.5 w-[200px]">
-            <p className="text-[11px] font-medium leading-tight mb-1">
+          <div className="rounded-lg border border-[#DDE3EA] bg-white px-3 py-2.5 shadow-md w-[200px]">
+            <p className="text-[11px] font-semibold text-[#102A43] leading-tight mb-1.5">
               {tooltip.category}
             </p>
-            <div className="flex items-center gap-2 text-[10px] text-white/70 mb-2">
-              <span>{formatNumber(tooltip.count)}</span>
-              <span className="text-white/40">·</span>
-              <span>{tooltip.percent.toFixed(1)}%</span>
+            <div className="flex items-center justify-between text-[10px] mb-2">
+              <span className="text-[#52667A]">
+                Count: <span className="font-semibold text-[#102A43]">{formatNumber(tooltip.count)}</span>
+              </span>
+              <span className="text-[#52667A]">
+                Share: <span className="font-semibold text-[#102A43]">{tooltip.percent.toFixed(1)}%</span>
+              </span>
             </div>
             {tooltip.sparkline.length > 1 && (
               <Sparkline

--- a/components/charts/heatmap-chart.tsx
+++ b/components/charts/heatmap-chart.tsx
@@ -114,11 +114,14 @@ export function HeatmapChart({ data }: HeatmapChartProps) {
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="absolute pointer-events-none z-10 rounded-md border border-[#DDE3EA] bg-white px-2 py-1 shadow-md -translate-x-1/2 -translate-y-full"
+          className="absolute pointer-events-none z-10 rounded-lg border border-[#DDE3EA] bg-white px-3 py-2 shadow-md -translate-x-1/2 -translate-y-full"
           style={{ left: tooltip.x, top: tooltip.y }}
         >
-          <p className="text-[10px] text-[#102A43] font-medium whitespace-nowrap">
-            {DAY_LABELS[tooltip.day]} {HOUR_LABELS[tooltip.hour]} — Avg per week: {tooltip.count} incidents
+          <p className="text-[11px] font-semibold text-[#102A43] whitespace-nowrap mb-0.5">
+            {DAY_LABELS[tooltip.day]} {HOUR_LABELS[tooltip.hour]}
+          </p>
+          <p className="text-[10px] text-[#52667A] whitespace-nowrap">
+            Avg per week: <span className="font-semibold text-[#102A43]">{tooltip.count}</span> incidents
           </p>
         </div>
       )}

--- a/components/ui/sparkline.tsx
+++ b/components/ui/sparkline.tsx
@@ -34,10 +34,11 @@ export function Sparkline({
     const date = formatDateShort(point.payload?.date);
     const value = formatNumber(point.value as number);
     return (
-      <div className="rounded-lg bg-[#102A43] px-2.5 py-1.5 text-[11px] text-white shadow-lg">
-        <span className="font-medium">{date}</span>
-        <span className="mx-1 text-white/50">·</span>
-        <span>{value} {metricLabel}</span>
+      <div className="rounded-lg border border-[#DDE3EA] bg-white px-3 py-2 shadow-md">
+        <p className="text-[11px] font-semibold text-[#102A43] mb-0.5">{date}</p>
+        <p className="text-[10px] text-[#52667A]">
+          {metricLabel}: <span className="font-semibold text-[#102A43]">{value}</span>
+        </p>
       </div>
     );
   }, [metricLabel]);


### PR DESCRIPTION
## Summary
- Changed CategoryChart tooltip from dark (#102A43) to white background with border
- Changed Sparkline tooltip from dark (#102A43) to white background with border
- Improved HeatmapChart tooltip formatting (split into title + value lines)
- All tooltips now share consistent style: white bg, #DDE3EA border, rounded-lg, shadow-md
- Added informational labels (Count, Share, metric name) instead of raw values

Closes #175

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (79/79)
- [ ] Visual check: hover over CategoryChart bars — white tooltip with count/share labels
- [ ] Visual check: hover over Sparkline in KPI cards — white tooltip with date and metric
- [ ] Visual check: hover over Heatmap cells — white tooltip with day/time and avg count
- [ ] Verify AqiTrend and ChangeLeaders tooltips unchanged (already white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)