### PR TITLE
Fix: map tooltip fonts/layout + AQI card alignment

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -137,7 +137,8 @@
   border-radius: 8px;
   padding: 6px 10px;
   box-shadow: 0 2px 6px rgba(16, 42, 67, 0.1);
-  font-family: inherit;
+  font-family: var(--font-sans, "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif);
+  line-height: 1.4;
 }
 
 .leaflet-tooltip-custom::before {

--- a/components/cards/kpi-card.tsx
+++ b/components/cards/kpi-card.tsx
@@ -70,7 +70,13 @@ export function KpiCard({
           <div className="text-[34px] font-bold text-[#102A43] leading-none mb-1">
             {formatNumber(value)}
           </div>
-          <DeltaBadge value={deltaPercent} />
+          {deltaPercent != null ? (
+            <DeltaBadge value={deltaPercent} />
+          ) : insight ? (
+            <p className="text-[10px] text-[#627D98] leading-tight line-clamp-1">{insight}</p>
+          ) : (
+            <div className="h-5" />
+          )}
         </div>
         <div className="min-w-0 flex-1 self-center">
           <Sparkline
@@ -82,7 +88,7 @@ export function KpiCard({
         </div>
       </div>
 
-      {insight && (
+      {insight && deltaPercent != null && (
         <p className="text-[10px] text-[#627D98] mt-1.5 leading-tight line-clamp-1">
           {insight}
         </p>

--- a/components/map/neighborhood-layer.tsx
+++ b/components/map/neighborhood-layer.tsx
@@ -70,13 +70,17 @@ export function NeighborhoodLayer({
       const row = dataMap.get(name);
 
       const lines = [
-        `<strong style="font-size:11px;color:#102A43">${name}</strong>`,
+        `<div style="font-size:11px;font-weight:600;color:#102A43;margin-bottom:2px">${name}</div>`,
         row
-          ? `<span style="font-size:10px;color:#52667A">Crime: ${formatNumber(row.crimeCount)} · Crashes: ${formatNumber(row.crashCount)} · 311: ${formatNumber(row.requests311Count)}</span>`
-          : '<span style="font-size:10px;color:#627D98">No data</span>',
+          ? [
+              `<div style="font-size:10px;color:#52667A">Crime: ${formatNumber(row.crimeCount)}</div>`,
+              `<div style="font-size:10px;color:#52667A">Crashes: ${formatNumber(row.crashCount)}</div>`,
+              `<div style="font-size:10px;color:#52667A">311: ${formatNumber(row.requests311Count)}</div>`,
+            ].join("")
+          : '<div style="font-size:10px;color:#627D98">No data</div>',
       ];
 
-      layer.bindTooltip(lines.join("<br/>"), {
+      layer.bindTooltip(lines.join(""), {
         sticky: true,
         direction: "top",
         className: "leaflet-tooltip-custom",


### PR DESCRIPTION
## Summary
- Sync map tooltip font to IBM Plex Sans (project font) via explicit `font-family` in `.leaflet-tooltip-custom`
- Render each metric (Crime, Crashes, 311) on its own line in the map tooltip
- Align AQI card main number with other KPI cards by showing insight text in the DeltaBadge slot when no delta is provided

Closes #177

## Test plan
- [ ] Hover over neighborhoods on the map — verify font matches other tooltips and metrics are on separate lines
- [ ] Compare AQI card number position with Crime/Crashes/311 cards — should be aligned
- [ ] Verify KPI cards with deltaPercent still show delta badge + insight correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)