### PR TITLE
Fix: anchor date ranges to MAX(date) for resilient time windows

### DIFF
--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -109,6 +109,31 @@ describe("City Pulse API", () => {
       expect(body.data).toBeDefined();
       expect(body.lastUpdated).toBeDefined();
     });
+
+    it("anchors date range to MAX(date) instead of NOW()", async () => {
+      // effectiveThrough
+      mockQuery.mockResolvedValueOnce([{ effective_through: "2026-03-01" }]);
+      // sparkline
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-01", crime_count: 5, crash_count: 2, requests_311_count: 10 },
+      ]);
+      // totals
+      mockQuery.mockResolvedValueOnce([
+        { crime_count: 50, crash_count: 20, requests_311_count: 100, crime_delta_pct: null, crash_delta_pct: null, requests_311_delta_pct: null },
+      ]);
+
+      await getKpis(makeRequest("http://localhost/api/city-pulse/kpis?timeWindow=7d"));
+
+      // effectiveThrough query (1st call) should use MAX(date) not NOW()
+      const etSql = mockQuery.mock.calls[0][0] as string;
+      expect(etSql).toContain("MAX(date)");
+      expect(etSql).not.toContain("NOW()");
+
+      // sparkline query (2nd call) should use MAX(date)
+      const sparkSql = mockQuery.mock.calls[1][0] as string;
+      expect(sparkSql).toContain("MAX(date)");
+      expect(sparkSql).not.toContain("NOW()");
+    });
   });
 
   describe("GET /api/city-pulse/categories", () => {

--- a/__tests__/api-environment.test.ts
+++ b/__tests__/api-environment.test.ts
@@ -79,6 +79,32 @@ describe("Environment API", () => {
       expect(body.data.trend).toHaveLength(2);
       expect(body.data.trend.map((t: { date: string }) => t.date)).toEqual(["2026-03-12", "2026-03-13"]);
     });
+
+    it("anchors date range to MAX(date) instead of CURRENT_DATE", async () => {
+      // current
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-01", aqi_max: 40, aqi_ozone: 35, aqi_pm25: 40, aqi_pm10: 20, category: "Good" },
+      ]);
+      // trend
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-02-26", aqi_max: 55, aqi_ozone: 50, aqi_pm25: 55, aqi_pm10: 30, category: "Moderate" },
+        { date: "2026-03-01", aqi_max: 40, aqi_ozone: 35, aqi_pm25: 40, aqi_pm10: 20, category: "Good" },
+      ]);
+      // effectiveThrough
+      mockQuery.mockResolvedValueOnce([{ effective_through: "2026-03-01" }]);
+
+      await getAqi(req("http://localhost/api/environment/aqi?timeWindow=7d"));
+
+      // Trend query (2nd call) should use MAX(date) not CURRENT_DATE
+      const trendSql = mockQuery.mock.calls[1][0] as string;
+      expect(trendSql).toContain("MAX(date)");
+      expect(trendSql).not.toContain("CURRENT_DATE");
+
+      // EffectiveThrough query (3rd call) should also use MAX(date)
+      const etSql = mockQuery.mock.calls[2][0] as string;
+      expect(etSql).toContain("MAX(date)");
+      expect(etSql).not.toContain("CURRENT_DATE");
+    });
   });
 
   describe("GET /api/environment/comparison", () => {

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -33,8 +33,8 @@ export async function getKpiSparkline(
       return query<DailyRow>(
         `SELECT date::text, crime_count, crash_count, requests_311_count
          FROM mart_city_pulse_daily
-         WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
-           AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+         WHERE date > (SELECT MAX(date) FROM mart_city_pulse_daily) - $1::int
+           AND date <= (SELECT MAX(date) FROM mart_city_pulse_daily)
          ORDER BY date DESC`,
         [days]
       );
@@ -46,41 +46,44 @@ export async function getKpiSparkline(
               SUM(crash_count)::int AS crash_count,
               SUM(requests_311_count)::int AS requests_311_count
        FROM mart_city_pulse_daily
-       WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
-         AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+       WHERE date > (SELECT MAX(date) FROM mart_city_pulse_daily) - $1::int
+         AND date <= (SELECT MAX(date) FROM mart_city_pulse_daily)
        GROUP BY DATE_TRUNC('week', date)
        ORDER BY date DESC`,
       [days]
     );
   }
   // Neighborhood-specific sparkline from staging tables
+  // Anchor to max available date from mart_city_pulse_daily
   if (days <= 30) {
     return query<DailyRow>(
-      `SELECT d.date::text,
+      `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily)
+       SELECT d.date::text,
               COALESCE(cr.cnt, 0)::int AS crime_count,
               COALESCE(ca.cnt, 0)::int AS crash_count,
               COALESCE(r.cnt, 0)::int AS requests_311_count
-       FROM generate_series(
-              (NOW() AT TIME ZONE 'America/Denver')::date - $1::int,
-              (NOW() AT TIME ZONE 'America/Denver')::date - 1,
+       FROM anchor,
+            generate_series(
+              anchor.d - $1::int + 1,
+              anchor.d,
               '1 day'::interval
             ) AS d(date)
        LEFT JOIN (
          SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
          FROM stg_crime WHERE neighborhood = $2
-           AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+           AND reported_date >= ((SELECT d FROM anchor) - $1::int)::date
          GROUP BY 1
        ) cr ON cr.date = d.date
        LEFT JOIN (
          SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
          FROM stg_crashes WHERE neighborhood = $2
-           AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+           AND reported_date >= ((SELECT d FROM anchor) - $1::int)::date
          GROUP BY 1
        ) ca ON ca.date = d.date
        LEFT JOIN (
          SELECT (case_created_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
          FROM stg_311 WHERE neighborhood = $2
-           AND case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+           AND case_created_date >= ((SELECT d FROM anchor) - $1::int)::date
          GROUP BY 1
        ) r ON r.date = d.date
        ORDER BY d.date DESC`,
@@ -89,31 +92,33 @@ export async function getKpiSparkline(
   }
   // 90d + neighborhood: aggregate by week
   return query<DailyRow>(
-    `SELECT DATE_TRUNC('week', d.date)::date::text AS date,
+    `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily)
+     SELECT DATE_TRUNC('week', d.date)::date::text AS date,
             SUM(COALESCE(cr.cnt, 0))::int AS crime_count,
             SUM(COALESCE(ca.cnt, 0))::int AS crash_count,
             SUM(COALESCE(r.cnt, 0))::int AS requests_311_count
-     FROM generate_series(
-            (NOW() AT TIME ZONE 'America/Denver')::date - $1::int,
-            (NOW() AT TIME ZONE 'America/Denver')::date - 1,
+     FROM anchor,
+          generate_series(
+            anchor.d - $1::int + 1,
+            anchor.d,
             '1 day'::interval
           ) AS d(date)
      LEFT JOIN (
        SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
        FROM stg_crime WHERE neighborhood = $2
-         AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         AND reported_date >= ((SELECT d FROM anchor) - $1::int)::date
        GROUP BY 1
      ) cr ON cr.date = d.date
      LEFT JOIN (
        SELECT (reported_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
        FROM stg_crashes WHERE neighborhood = $2
-         AND reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         AND reported_date >= ((SELECT d FROM anchor) - $1::int)::date
        GROUP BY 1
      ) ca ON ca.date = d.date
      LEFT JOIN (
        SELECT (case_created_date AT TIME ZONE 'America/Denver')::date AS date, COUNT(*) AS cnt
        FROM stg_311 WHERE neighborhood = $2
-         AND case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+         AND case_created_date >= ((SELECT d FROM anchor) - $1::int)::date
        GROUP BY 1
      ) r ON r.date = d.date
      GROUP BY DATE_TRUNC('week', d.date)
@@ -131,10 +136,10 @@ export async function getKpiTotals(
     const days = daysForWindow(tw);
     const upperBound = effectiveThrough
       ? `$2::date + 1`
-      : `(NOW() AT TIME ZONE 'America/Denver')::date`;
+      : `(SELECT MAX(date) + 1 FROM mart_city_pulse_daily)`;
     const prevUpperBound = effectiveThrough
       ? `$2::date + 1 - $1::int`
-      : `(NOW() AT TIME ZONE 'America/Denver')::date - $1::int`;
+      : `(SELECT MAX(date) + 1 FROM mart_city_pulse_daily) - $1::int`;
     const params: (number | string)[] = effectiveThrough
       ? [days, effectiveThrough]
       : [days];
@@ -190,7 +195,7 @@ export async function getEffectiveThrough(tw: TimeWindow): Promise<string | null
      FROM (
        SELECT domain, MAX(date) AS max_date
        FROM mart_incident_trends
-       WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
+       WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
        GROUP BY domain
      ) sub`,
     [days]
@@ -215,8 +220,8 @@ export async function getCategoryTrends(
     return query<CategoryTrendRow>(
       `SELECT domain, category, date::text, count
        FROM mart_incident_trends
-       WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
-         AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+       WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
+         AND date <= (SELECT MAX(date) FROM mart_incident_trends)
        ORDER BY domain, category, date`,
       [days]
     );
@@ -227,8 +232,8 @@ export async function getCategoryTrends(
             DATE_TRUNC('week', date)::date::text AS date,
             SUM(count)::int AS count
      FROM mart_incident_trends
-     WHERE date >= (NOW() AT TIME ZONE 'America/Denver')::date - $1::int
-       AND date < (NOW() AT TIME ZONE 'America/Denver')::date
+     WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
+       AND date <= (SELECT MAX(date) FROM mart_incident_trends)
      GROUP BY domain, category, DATE_TRUNC('week', date)
      ORDER BY domain, category, date`,
     [days]
@@ -306,4 +311,3 @@ export async function getNeighborhoodBreakdown(
     [tw]
   );
 }
-

--- a/lib/queries/environment.ts
+++ b/lib/queries/environment.ts
@@ -21,7 +21,7 @@ export async function getAqiTrend(tw: TimeWindow): Promise<AqiRow[]> {
   return query<AqiRow>(
     `SELECT date::text, aqi_max, aqi_ozone, aqi_pm25, aqi_pm10, category
      FROM mart_aqi_daily
-     WHERE date >= CURRENT_DATE - $1::int
+     WHERE date > (SELECT MAX(date) FROM mart_aqi_daily) - $1::int
      ORDER BY date`,
     [days]
   );
@@ -41,7 +41,7 @@ export async function getAqiEffectiveThrough(tw: TimeWindow): Promise<string | n
   const rows = await query<{ effective_through: string }>(
     `SELECT MAX(date)::text AS effective_through
      FROM mart_aqi_daily
-     WHERE date >= CURRENT_DATE - $1::int`,
+     WHERE date > (SELECT MAX(date) FROM mart_aqi_daily) - $1::int`,
     [days]
   );
   return rows[0]?.effective_through ?? null;


### PR DESCRIPTION
## Summary
- Replaced all `CURRENT_DATE` / `NOW()` anchors in runtime SQL queries with `MAX(date)` from respective mart tables
- Dashboard now shows data based on the most recent available date, not the current date
- Fixes empty charts (e.g. "No AQI data available") when data lags behind current date for short time windows (7D)

### Changed files
- `lib/queries/environment.ts` — `getAqiTrend()`, `getAqiEffectiveThrough()`
- `lib/queries/city-pulse.ts` — `getKpiSparkline()`, `getKpiTotals()`, `getEffectiveThrough()`, `getCategoryTrends()`
- Regression tests in both `api-environment.test.ts` and `api-city-pulse.test.ts`

## Test plan
- [x] ESLint passes
- [x] All 81 tests pass (regression tests verify SQL contains `MAX(date)` and not `CURRENT_DATE`/`NOW()`)
- [ ] Manual: set filter to 7D — AQI Trend and all charts should display data
- [ ] Manual: verify 30D and 90D still work correctly

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)