### PR TITLE
Fix: make effectiveThrough window-independent to prevent over-trimming

### DIFF
--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -188,17 +188,14 @@ export async function getKpiTotals(
   return rows[0] ?? null;
 }
 
-export async function getEffectiveThrough(tw: TimeWindow): Promise<string | null> {
-  const days = daysForWindow(tw);
+export async function getEffectiveThrough(_tw: TimeWindow): Promise<string | null> {
   const rows = await query<{ effective_through: string | null }>(
     `SELECT MIN(max_date)::text AS effective_through
      FROM (
        SELECT domain, MAX(date) AS max_date
        FROM mart_incident_trends
-       WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
        GROUP BY domain
-     ) sub`,
-    [days]
+     ) sub`
   );
   return rows[0]?.effective_through ?? null;
 }

--- a/lib/queries/environment.ts
+++ b/lib/queries/environment.ts
@@ -36,13 +36,10 @@ export async function getAqiCurrent(): Promise<AqiRow | null> {
   return rows[0] ?? null;
 }
 
-export async function getAqiEffectiveThrough(tw: TimeWindow): Promise<string | null> {
-  const days = daysForWindow(tw);
+export async function getAqiEffectiveThrough(_tw: TimeWindow): Promise<string | null> {
   const rows = await query<{ effective_through: string }>(
     `SELECT MAX(date)::text AS effective_through
-     FROM mart_aqi_daily
-     WHERE date > (SELECT MAX(date) FROM mart_aqi_daily) - $1::int`,
-    [days]
+     FROM mart_aqi_daily`
   );
   return rows[0]?.effective_through ?? null;
 }


### PR DESCRIPTION
## Summary
- Removed time window filter from `getEffectiveThrough()` and `getAqiEffectiveThrough()` 
- effectiveThrough now returns the global latest date where all data sources have complete data, not a windowed calculation
- Fixes sparklines being trimmed to 1 day when different mart tables have different MAX dates

### Root cause
After #179 fix, `getEffectiveThrough()` anchored to `MAX(date) FROM mart_incident_trends` while `getKpiSparkline()` anchored to `MAX(date) FROM mart_city_pulse_daily`. Different MAX dates caused effectiveThrough to over-trim sparkline data.

## Test plan
- [x] ESLint passes (2 warnings for unused `_tw` params — intentional for API stability)
- [x] All 81 tests pass
- [ ] Manual: 7D filter shows 7 days of data across all charts
- [ ] Manual: 30D and 90D still work correctly

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)