### PR TITLE
Fix: split heatmap into Crime and Crashes, fix tooltip and Y-axis

### DIFF
--- a/__tests__/page-city-pulse.test.tsx
+++ b/__tests__/page-city-pulse.test.tsx
@@ -85,7 +85,8 @@ describe("CityPulsePage", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       loading: true,
       error: null,
@@ -104,7 +105,8 @@ describe("CityPulsePage", () => {
         requests311: { value: 2500, delta: 0, deltaPercent: 1.0, sparkline: [], insight: "", tag: "30D" },
       },
       categories: { crime: [{ category: "Theft", count: 500, percent: 40 }] },
-      heatmap: [{ dayOfWeek: 0, hourOfDay: 12, count: 50 }],
+      heatmapCrime: [{ dayOfWeek: 0, hourOfDay: 12, count: 50 }],
+      heatmapCrashes: [{ dayOfWeek: 1, hourOfDay: 18, count: 30 }],
       neighborhoods: [{ neighborhood: "Five Points", crimeCount: 100, crashCount: 20, requests311Count: 50, totalDeltaPct: 3.5 }],
       loading: false,
       error: null,
@@ -123,7 +125,8 @@ describe("CityPulsePage", () => {
         requests311: { value: 200, delta: 0, deltaPercent: 0, sparkline: [], insight: "", tag: "30D" },
       },
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       loading: false,
       error: null,
@@ -140,7 +143,8 @@ describe("CityPulsePage", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       loading: false,
       error: null,
@@ -150,7 +154,8 @@ describe("CityPulsePage", () => {
     expect(screen.getByText("Neighborhood Map")).toBeInTheDocument();
     expect(screen.getByText("Category Breakdown")).toBeInTheDocument();
     expect(screen.getByText("AQI Trend")).toBeInTheDocument();
-    expect(screen.getByText("Time Heatmap")).toBeInTheDocument();
+    expect(screen.getByText("Crime by Hour & Day")).toBeInTheDocument();
+    expect(screen.getByText("Crashes by Hour & Day")).toBeInTheDocument();
     expect(screen.getByText("Change Leaders")).toBeInTheDocument();
   });
 
@@ -158,7 +163,8 @@ describe("CityPulsePage", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       loading: false,
       error: null,
@@ -169,15 +175,16 @@ describe("CityPulsePage", () => {
     expect(container.querySelector(".grid-cols-1.sm\\:grid-cols-2.lg\\:grid-cols-12")).toBeInTheDocument();
     // Map + categories row: 1-col mobile, 12-col lg
     expect(container.querySelector(".grid-cols-1.lg\\:grid-cols-12")).toBeInTheDocument();
-    // AQI + heatmap row: 1-col mobile, 12-col md
-    expect(container.querySelector(".grid-cols-1.md\\:grid-cols-12")).toBeInTheDocument();
+    // Heatmap row: 1-col mobile, 2-col md
+    expect(container.querySelector(".grid-cols-1.md\\:grid-cols-2")).toBeInTheDocument();
   });
 
   it("uses global effectiveThrough (min of city-pulse and environment) for header", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       effectiveThrough: "2026-03-09",
       lastUpdated: "2026-03-16T06:00:00Z",
@@ -223,7 +230,8 @@ describe("CityPulsePage", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       effectiveThrough: "2026-03-09",
       lastUpdated: "2026-03-16T06:00:00Z",
@@ -255,7 +263,8 @@ describe("CityPulsePage", () => {
     mockUseCityPulseData.mockReturnValue({
       kpis: null,
       categories: {},
-      heatmap: [],
+      heatmapCrime: [],
+      heatmapCrashes: [],
       neighborhoods: [],
       loading: false,
       error: "Connection refused",

--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -36,7 +36,7 @@ describe("CityPulsePage", () => {
 
   it("renders grid structure with expected sections", () => {
     const { container } = render(<CityPulsePage />);
-    // 3 grid sections: KPI row, map+categories row, AQI trend+heatmap row
+    // 3 grid sections: KPI row, map+categories row, heatmaps row
     const grids = container.querySelectorAll(".grid");
     expect(grids.length).toBe(3);
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ import geojson from "@/data/geo/denver-neighborhoods.json";
 
 function CityPulseContent() {
   const { timeWindow, neighborhood } = useFilters();
-  const { kpis, categories, categoryTrends, heatmap, neighborhoods, loading, error, retry, effectiveThrough, lastUpdated } =
+  const { kpis, categories, categoryTrends, heatmapCrime, heatmapCrashes, neighborhoods, loading, error, retry, effectiveThrough, lastUpdated } =
     useCityPulseData(timeWindow, neighborhood);
   const { aqi, comparison, loading: envLoading, error: envError, retry: envRetry, effectiveThrough: envEffectiveThrough } =
     useEnvironmentData(timeWindow, neighborhood);
@@ -147,17 +147,22 @@ function CityPulseContent() {
         </div>
       </div>
 
-      {/* Row 3: AQI Trend (7/12) + Time Heatmap (5/12) */}
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
-        <ChartCard title="AQI Trend" loading={envLoading} className="md:col-span-7">
-          <AqiTrendChart data={aqi.trend} />
+      {/* Row 3: AQI Trend (full-width) */}
+      <ChartCard title="AQI Trend" loading={envLoading}>
+        <AqiTrendChart data={aqi.trend} />
+      </ChartCard>
+
+      {/* Row 4: Heatmaps — Crime + Crashes side by side */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <ChartCard title="Crime by Hour & Day" loading={loading}>
+          <HeatmapChart data={heatmapCrime} />
         </ChartCard>
-        <ChartCard title="Time Heatmap" loading={loading} className="md:col-span-5">
-          <HeatmapChart data={heatmap} />
+        <ChartCard title="Crashes by Hour & Day" loading={loading}>
+          <HeatmapChart data={heatmapCrashes} />
         </ChartCard>
       </div>
 
-      {/* Row 4: Change Leaders (full-width) */}
+      {/* Row 5: Change Leaders (full-width) */}
       <ChartCard title="Change Leaders" loading={envLoading}>
         <ChangeLeadersChart data={comparison} />
       </ChartCard>
@@ -196,11 +201,14 @@ function CityPulseSkeleton() {
           </ChartCard>
         </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
-        <ChartCard title="AQI Trend" loading className="md:col-span-7">
+      <ChartCard title="AQI Trend" loading>
+        <div className="h-48" />
+      </ChartCard>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <ChartCard title="Crime by Hour & Day" loading>
           <div className="h-48" />
         </ChartCard>
-        <ChartCard title="Time Heatmap" loading className="md:col-span-5">
+        <ChartCard title="Crashes by Hour & Day" loading>
           <div className="h-48" />
         </ChartCard>
       </div>

--- a/components/charts/heatmap-chart.tsx
+++ b/components/charts/heatmap-chart.tsx
@@ -7,12 +7,13 @@ interface HeatmapChartProps {
   data: HeatmapCell[];
 }
 
+const CELL_HEIGHT = 12;
+const GAP = 1;
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const HOUR_LABELS = Array.from({ length: 24 }, (_, i) => `${i}:00`);
 const COLOR_LIGHT = "#EEF3F8";
 
 function interpolateColor(ratio: number): string {
-  // Linear interpolation from COLOR_LIGHT to COLOR_DARK
   const r1 = 0xee, g1 = 0xf3, b1 = 0xf8;
   const r2 = 0x0b, g2 = 0x4f, b2 = 0x8c;
   const r = Math.round(r1 + (r2 - r1) * ratio);
@@ -74,21 +75,21 @@ export function HeatmapChart({ data }: HeatmapChartProps) {
 
       {/* Grid */}
       <div className="flex">
-        {/* Hour labels (left) */}
-        <div className="flex flex-col w-10 shrink-0">
+        {/* Hour labels (left) — same gap-px as cells to stay aligned */}
+        <div className="flex flex-col w-10 shrink-0" style={{ gap: GAP }}>
           {HOUR_LABELS.map((h, i) => (
             <div
               key={h}
               className="flex items-center justify-end pr-1.5 text-[8px] text-[#627D98]"
-              style={{ height: 10 }}
+              style={{ height: CELL_HEIGHT }}
             >
-              {i % 3 === 0 ? h : ""}
+              {i % 2 === 0 ? h : ""}
             </div>
           ))}
         </div>
 
         {/* Cells */}
-        <div className="flex-1 grid grid-cols-7 gap-px">
+        <div className="flex-1 grid grid-cols-7" style={{ gap: GAP }}>
           {Array.from({ length: 24 }, (_, hour) =>
             Array.from({ length: 7 }, (_, day) => {
               const count = grid[hour][day];
@@ -99,7 +100,7 @@ export function HeatmapChart({ data }: HeatmapChartProps) {
                   data-cell
                   className="rounded-[1px] cursor-pointer transition-opacity hover:opacity-80"
                   style={{
-                    height: 10,
+                    height: CELL_HEIGHT,
                     backgroundColor: count > 0 ? interpolateColor(ratio) : COLOR_LIGHT,
                   }}
                   onMouseEnter={(e) => handleMouseEnter(hour, day, count, e)}
@@ -121,7 +122,7 @@ export function HeatmapChart({ data }: HeatmapChartProps) {
             {DAY_LABELS[tooltip.day]} {HOUR_LABELS[tooltip.hour]}
           </p>
           <p className="text-[10px] text-[#52667A] whitespace-nowrap">
-            Avg per week: <span className="font-semibold text-[#102A43]">{tooltip.count}</span> incidents
+            <span className="font-semibold text-[#102A43]">{tooltip.count.toLocaleString()}</span> incidents
           </p>
         </div>
       )}

--- a/lib/hooks/use-city-pulse-data.ts
+++ b/lib/hooks/use-city-pulse-data.ts
@@ -14,7 +14,8 @@ interface CityPulseData {
   kpis: { crime: KpiData; crashes: KpiData; requests311: KpiData } | null;
   categories: Record<string, CategoryBreakdown[]>;
   categoryTrends: CategoryTrends;
-  heatmap: HeatmapCell[];
+  heatmapCrime: HeatmapCell[];
+  heatmapCrashes: HeatmapCell[];
   neighborhoods: NeighborhoodRow[];
   effectiveThrough: string | null;
   lastUpdated: string | null;
@@ -39,7 +40,8 @@ export function useCityPulseData(
     kpis: null,
     categories: {},
     categoryTrends: {},
-    heatmap: [],
+    heatmapCrime: [],
+    heatmapCrashes: [],
     neighborhoods: [],
     effectiveThrough: null,
     lastUpdated: null,
@@ -59,14 +61,15 @@ export function useCityPulseData(
         return r.json();
       });
 
-      const [categories, categoryTrends, heatmap, neighborhoods] = await Promise.all([
+      const [categories, categoryTrends, heatmapCrime, heatmapCrashes, neighborhoods] = await Promise.all([
         fetchJson<Record<string, CategoryBreakdown[]>>(
           `/api/city-pulse/categories?${qs}`
         ),
         fetchJson<CategoryTrends>(
           `/api/city-pulse/category-trends?timeWindow=${timeWindow}`
         ),
-        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?${qs}`),
+        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?timeWindow=${timeWindow}&domain=crime`),
+        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?timeWindow=${timeWindow}&domain=crashes`),
         fetchJson<NeighborhoodRow[]>(
           `/api/city-pulse/neighborhoods?timeWindow=${timeWindow}`
         ),
@@ -76,7 +79,8 @@ export function useCityPulseData(
         kpis: kpisResp.data,
         categories,
         categoryTrends,
-        heatmap,
+        heatmapCrime,
+        heatmapCrashes,
         neighborhoods,
         effectiveThrough: kpisResp.effectiveThrough ?? null,
         lastUpdated: kpisResp.lastUpdated ?? null,


### PR DESCRIPTION
## Summary
- **Split** single "Time Heatmap" into two side-by-side heatmaps: **Crime by Hour & Day** and **Crashes by Hour & Day** (removed 311 from heatmap)
- **Fixed misleading tooltip**: was "Avg per week: N" (actually an avg across domains, not per week) → now shows plain incident count
- **Fixed Y-axis alignment**: hour labels used `flex` without gap while cells used `grid` with `gap-px`, causing ~23px drift by row 24. Now both use the same gap
- **Increased cell height** from 10px to 12px, show every 2nd hour label instead of every 3rd for better readability
- **AQI Trend** now takes full width (was sharing row with heatmap)

Closes #185

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 82 passed
- [x] `npm run build` — success
- [ ] Visual check: two heatmaps render side-by-side on desktop, stack on mobile
- [ ] Hover tooltip shows "N incidents" without "Avg per week"
- [ ] Y-axis labels align with cell rows at all hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)