### PR TITLE
Fix: merge Crime/Crashes heatmaps into one chart with toggle

### DIFF
--- a/__tests__/page-city-pulse.test.tsx
+++ b/__tests__/page-city-pulse.test.tsx
@@ -154,8 +154,7 @@ describe("CityPulsePage", () => {
     expect(screen.getByText("Neighborhood Map")).toBeInTheDocument();
     expect(screen.getByText("Category Breakdown")).toBeInTheDocument();
     expect(screen.getByText("AQI Trend")).toBeInTheDocument();
-    expect(screen.getByText("Crime by Hour & Day")).toBeInTheDocument();
-    expect(screen.getByText("Crashes by Hour & Day")).toBeInTheDocument();
+    expect(screen.getByText("Time Heatmap")).toBeInTheDocument();
     expect(screen.getByText("Change Leaders")).toBeInTheDocument();
   });
 
@@ -173,10 +172,9 @@ describe("CityPulsePage", () => {
     const { container } = render(<CityPulsePage />);
     // KPI row: 1-col mobile, 2-col sm, 12-col lg
     expect(container.querySelector(".grid-cols-1.sm\\:grid-cols-2.lg\\:grid-cols-12")).toBeInTheDocument();
-    // Map + categories row: 1-col mobile, 12-col lg
-    expect(container.querySelector(".grid-cols-1.lg\\:grid-cols-12")).toBeInTheDocument();
-    // Heatmap row: 1-col mobile, 2-col md
-    expect(container.querySelector(".grid-cols-1.md\\:grid-cols-2")).toBeInTheDocument();
+    // Map + categories row AND AQI + heatmap row: 1-col mobile, 12-col lg
+    const lgGridRows = container.querySelectorAll(".grid-cols-1.lg\\:grid-cols-12");
+    expect(lgGridRows.length).toBeGreaterThanOrEqual(2);
   });
 
   it("uses global effectiveThrough (min of city-pulse and environment) for header", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { useState, Suspense } from "react";
 import { PageShell } from "@/components/layout/page-shell";
 import { KpiCard } from "@/components/cards/kpi-card";
 import { ChartCard } from "@/components/cards/chart-card";
@@ -16,8 +16,41 @@ import { ErrorCard } from "@/components/cards/error-card";
 import { formatAqi } from "@/lib/format";
 import geojson from "@/data/geo/denver-neighborhoods.json";
 
+type HeatmapDomain = "crime" | "crashes";
+
+function HeatmapDomainToggle({
+  value,
+  onChange,
+}: {
+  value: HeatmapDomain;
+  onChange: (v: HeatmapDomain) => void;
+}) {
+  const options: { key: HeatmapDomain; label: string }[] = [
+    { key: "crime", label: "Crime" },
+    { key: "crashes", label: "Crashes" },
+  ];
+  return (
+    <div className="flex rounded-md bg-[#F0F4F8] p-0.5 gap-0.5">
+      {options.map((o) => (
+        <button
+          key={o.key}
+          onClick={() => onChange(o.key)}
+          className={`px-2 py-0.5 text-[10px] font-semibold rounded transition-colors ${
+            value === o.key
+              ? "bg-white text-[#102A43] shadow-sm"
+              : "text-[#627D98] hover:text-[#334E68]"
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function CityPulseContent() {
   const { timeWindow, neighborhood } = useFilters();
+  const [heatmapDomain, setHeatmapDomain] = useState<HeatmapDomain>("crime");
   const { kpis, categories, categoryTrends, heatmapCrime, heatmapCrashes, neighborhoods, loading, error, retry, effectiveThrough, lastUpdated } =
     useCityPulseData(timeWindow, neighborhood);
   const { aqi, comparison, loading: envLoading, error: envError, retry: envRetry, effectiveThrough: envEffectiveThrough } =
@@ -147,19 +180,28 @@ function CityPulseContent() {
         </div>
       </div>
 
-      {/* Row 3: AQI Trend (full-width) */}
-      <ChartCard title="AQI Trend" loading={envLoading}>
-        <AqiTrendChart data={aqi.trend} />
-      </ChartCard>
-
-      {/* Row 4: Heatmaps — Crime + Crashes side by side */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <ChartCard title="Crime by Hour & Day" loading={loading}>
-          <HeatmapChart data={heatmapCrime} />
-        </ChartCard>
-        <ChartCard title="Crashes by Hour & Day" loading={loading}>
-          <HeatmapChart data={heatmapCrashes} />
-        </ChartCard>
+      {/* Row 3: AQI Trend (7/12) + Time Heatmap (5/12) */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 items-stretch">
+        <div className="lg:col-span-7">
+          <ChartCard title="AQI Trend" loading={envLoading} className="h-full">
+            <AqiTrendChart data={aqi.trend} />
+          </ChartCard>
+        </div>
+        <div className="lg:col-span-5">
+          <ChartCard
+            title="Time Heatmap"
+            loading={loading}
+            className="h-full"
+            headerRight={
+              <HeatmapDomainToggle
+                value={heatmapDomain}
+                onChange={setHeatmapDomain}
+              />
+            }
+          >
+            <HeatmapChart data={heatmapDomain === "crime" ? heatmapCrime : heatmapCrashes} />
+          </ChartCard>
+        </div>
       </div>
 
       {/* Row 5: Change Leaders (full-width) */}
@@ -201,16 +243,17 @@ function CityPulseSkeleton() {
           </ChartCard>
         </div>
       </div>
-      <ChartCard title="AQI Trend" loading>
-        <div className="h-48" />
-      </ChartCard>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <ChartCard title="Crime by Hour & Day" loading>
-          <div className="h-48" />
-        </ChartCard>
-        <ChartCard title="Crashes by Hour & Day" loading>
-          <div className="h-48" />
-        </ChartCard>
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3">
+        <div className="lg:col-span-7">
+          <ChartCard title="AQI Trend" loading>
+            <div className="h-48" />
+          </ChartCard>
+        </div>
+        <div className="lg:col-span-5">
+          <ChartCard title="Time Heatmap" loading>
+            <div className="h-48" />
+          </ChartCard>
+        </div>
       </div>
       <ChartCard title="Change Leaders" loading>
         <div className="h-48" />

--- a/components/cards/chart-card.tsx
+++ b/components/cards/chart-card.tsx
@@ -6,9 +6,10 @@ interface ChartCardProps {
   insight?: string;
   loading?: boolean;
   className?: string;
+  headerRight?: React.ReactNode;
 }
 
-export function ChartCard({ title, children, insight, loading, className }: ChartCardProps) {
+export function ChartCard({ title, children, insight, loading, className, headerRight }: ChartCardProps) {
   if (loading) {
     return (
       <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] ${className ?? ""}`}>
@@ -21,7 +22,10 @@ export function ChartCard({ title, children, insight, loading, className }: Char
 
   return (
     <div className={`rounded-[14px] bg-white border border-[#DDE3EA] p-3.5 shadow-[0_2px_6px_#102A4310] flex flex-col ${className ?? ""}`}>
-      <h3 className="text-xs font-bold text-[#102A43] mb-2 truncate">{title}</h3>
+      <div className="flex items-center justify-between mb-2 gap-2">
+        <h3 className="text-xs font-bold text-[#102A43] truncate">{title}</h3>
+        {headerRight}
+      </div>
       <div className="bg-[#F8FAFC] rounded-lg p-2 flex-1 flex flex-col min-h-0">{children}</div>
       {insight && (
         <p className="text-[10px] text-[#6B7B8D] mt-2 leading-tight">


### PR DESCRIPTION
## Summary
- Merged two separate heatmap cards (Crime / Crashes) back into a single "Time Heatmap" card
- Added a segmented toggle switch (Crime / Crashes) in the top-right corner of the card header
- Restored the original layout: AQI Trend (7/12) + Heatmap (5/12) side by side
- Added `headerRight` prop to `ChartCard` for reusable header actions

Closes #187

## Test plan
- [x] Lint passes (0 errors)
- [x] All 82 tests pass
- [x] Production build succeeds
- [ ] Visual check: toggle switches between Crime and Crashes data
- [ ] Visual check: heatmap sits to the right of AQI Trend on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)