### PR TITLE
Fix: rename Time Heatmap to Incidents by Day & Hour

### DIFF
--- a/__tests__/page-city-pulse.test.tsx
+++ b/__tests__/page-city-pulse.test.tsx
@@ -154,7 +154,7 @@ describe("CityPulsePage", () => {
     expect(screen.getByText("Neighborhood Map")).toBeInTheDocument();
     expect(screen.getByText("Category Breakdown")).toBeInTheDocument();
     expect(screen.getByText("AQI Trend")).toBeInTheDocument();
-    expect(screen.getByText("Time Heatmap")).toBeInTheDocument();
+    expect(screen.getByText("Incidents by Day & Hour")).toBeInTheDocument();
     expect(screen.getByText("Change Leaders")).toBeInTheDocument();
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -180,7 +180,7 @@ function CityPulseContent() {
         </div>
       </div>
 
-      {/* Row 3: AQI Trend (7/12) + Time Heatmap (5/12) */}
+      {/* Row 3: AQI Trend (7/12) + Incidents by Day & Hour (5/12) */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 items-stretch">
         <div className="lg:col-span-7">
           <ChartCard title="AQI Trend" loading={envLoading} className="h-full">
@@ -189,7 +189,7 @@ function CityPulseContent() {
         </div>
         <div className="lg:col-span-5">
           <ChartCard
-            title="Time Heatmap"
+            title="Incidents by Day & Hour"
             loading={loading}
             className="h-full"
             headerRight={
@@ -250,7 +250,7 @@ function CityPulseSkeleton() {
           </ChartCard>
         </div>
         <div className="lg:col-span-5">
-          <ChartCard title="Time Heatmap" loading>
+          <ChartCard title="Incidents by Day & Hour" loading>
             <div className="h-48" />
           </ChartCard>
         </div>


### PR DESCRIPTION
## Summary
- Renamed chart title from generic "Time Heatmap" to descriptive "Incidents by Day & Hour" — makes it immediately clear what data is shown and how it's sliced
- Updated both the live chart and the loading skeleton
- Updated test assertion to match new title
- Investigated data accuracy: counts confirmed correct against raw `stg_crime` table (~3,700 crimes/30d, small per-cell numbers are expected for 168 hour×day slots)

Closes #189

## Test plan
- [x] `npm run lint` — passes (0 errors)
- [x] `npm test` — 82 tests pass
- [ ] Visual check: chart title reads "Incidents by Day & Hour"

🤖 Generated with [Claude Code](https://claude.com/claude-code)