### PR TITLE
Fix: AQI Trend chart does not fill its card area

### DIFF
--- a/components/charts/aqi-trend-chart.tsx
+++ b/components/charts/aqi-trend-chart.tsx
@@ -81,7 +81,8 @@ export function AqiTrendChart({ data }: AqiTrendChartProps) {
   const ticks = evenlySpacedTicks(data);
 
   return (
-    <ResponsiveContainer width="100%" height={220}>
+    <div className="flex-1 min-h-0" style={{ minHeight: 180 }}>
+    <ResponsiveContainer width="100%" height="100%">
       <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -12 }}>
         {AQI_BANDS.map((band) => (
           <ReferenceArea
@@ -130,5 +131,6 @@ export function AqiTrendChart({ data }: AqiTrendChartProps) {
         />
       </AreaChart>
     </ResponsiveContainer>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace fixed `height={220}` on `ResponsiveContainer` with `height="100%"` + a flex wrapper so the AQI Trend chart expands to fill the full card height

Closes #191

## Test plan
- [ ] Open City Pulse dashboard
- [ ] Verify AQI Trend chart fills the full card height (no empty space below the chart)
- [ ] Verify chart still renders correctly at different viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)