### PR TITLE
fix: replace NOW() with data_anchor CTE in mart build scripts

### DIFF
--- a/data/marts/build_category_breakdown.py
+++ b/data/marts/build_category_breakdown.py
@@ -44,6 +44,13 @@ CRASH_LABEL_SQL = """
 
 # Insert counts first, then update percentages
 INSERT_SQL = """
+WITH data_anchor AS (
+    SELECT LEAST(
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crime),
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crashes),
+        (SELECT MAX((case_created_date AT TIME ZONE 'America/Denver')::date) FROM stg_311)
+    ) AS ref_date
+)
 INSERT INTO mart_category_breakdown (
     period, domain, category, count, pct_of_total, updated_at
 )
@@ -52,8 +59,8 @@ SELECT
     %(period)s, 'crime',
     {crime_label},
     COUNT(*), 0, NOW()
-FROM stg_crime
-WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+FROM stg_crime CROSS JOIN data_anchor
+WHERE reported_date >= data_anchor.ref_date - %(days)s
 GROUP BY {crime_label}
 
 UNION ALL
@@ -63,8 +70,8 @@ SELECT
     %(period)s, 'crashes',
     {crash_label},
     COUNT(*), 0, NOW()
-FROM stg_crashes
-WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+FROM stg_crashes CROSS JOIN data_anchor
+WHERE reported_date >= data_anchor.ref_date - %(days)s
 GROUP BY {crash_label}
 
 UNION ALL
@@ -74,8 +81,8 @@ SELECT
     %(period)s, '311',
     COALESCE(NULLIF(agency, ''), 'Other'),
     COUNT(*), 0, NOW()
-FROM stg_311
-WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+FROM stg_311 CROSS JOIN data_anchor
+WHERE case_created_date >= data_anchor.ref_date - %(days)s
 GROUP BY agency
 
 ON CONFLICT (period, domain, category) DO UPDATE SET

--- a/data/marts/build_city_pulse_neighborhood.py
+++ b/data/marts/build_city_pulse_neighborhood.py
@@ -17,6 +17,13 @@ logger = logging.getLogger(__name__)
 
 # Template SQL for one period
 PERIOD_SQL = """
+WITH data_anchor AS (
+    SELECT LEAST(
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crime),
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crashes),
+        (SELECT MAX((case_created_date AT TIME ZONE 'America/Denver')::date) FROM stg_311)
+    ) AS ref_date
+)
 INSERT INTO mart_city_pulse_neighborhood (
     neighborhood, period,
     crime_count, crash_count, requests_311_count, total_incidents,
@@ -49,6 +56,7 @@ SELECT
 FROM (
     SELECT canonical_name AS neighborhood FROM ref_neighborhoods
 ) n
+CROSS JOIN data_anchor
 LEFT JOIN (
     -- Current period counts
     SELECT neighborhood,
@@ -56,14 +64,14 @@ LEFT JOIN (
            SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
-        SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
+        WHERE case_created_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
 ) cur ON cur.neighborhood = n.neighborhood
@@ -74,19 +82,19 @@ LEFT JOIN (
            SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
-        SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
-          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+        SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
+          AND reported_date < data_anchor.ref_date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
-          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+        SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
+          AND reported_date < data_anchor.ref_date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
-          AND case_created_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+        SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
+        WHERE case_created_date >= data_anchor.ref_date - %(days)s * 2
+          AND case_created_date < data_anchor.ref_date - %(days)s
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood

--- a/data/marts/build_heatmap.py
+++ b/data/marts/build_heatmap.py
@@ -15,6 +15,13 @@ from db import count_rows, execute_sql, truncate_table
 logger = logging.getLogger(__name__)
 
 HEATMAP_SQL = """
+WITH data_anchor AS (
+    SELECT LEAST(
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crime),
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crashes),
+        (SELECT MAX((case_created_date AT TIME ZONE 'America/Denver')::date) FROM stg_311)
+    ) AS ref_date
+)
 INSERT INTO mart_heatmap_hour_day (
     period, domain, day_of_week, hour_of_day, count, updated_at
 )
@@ -26,8 +33,8 @@ SELECT
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint,
     COUNT(*),
     NOW()
-FROM stg_crime
-WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+FROM stg_crime CROSS JOIN data_anchor
+WHERE reported_date >= data_anchor.ref_date - %(days)s
 GROUP BY
     EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
@@ -42,8 +49,8 @@ SELECT
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint,
     COUNT(*),
     NOW()
-FROM stg_crashes
-WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+FROM stg_crashes CROSS JOIN data_anchor
+WHERE reported_date >= data_anchor.ref_date - %(days)s
 GROUP BY
     EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
@@ -58,8 +65,8 @@ SELECT
     EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')::smallint,
     COUNT(*),
     NOW()
-FROM stg_311
-WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+FROM stg_311 CROSS JOIN data_anchor
+WHERE case_created_date >= data_anchor.ref_date - %(days)s
 GROUP BY
     EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -15,6 +15,13 @@ from db import count_rows, execute_sql, truncate_table
 logger = logging.getLogger(__name__)
 
 COMPARISON_SQL = """
+WITH data_anchor AS (
+    SELECT LEAST(
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crime),
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crashes),
+        (SELECT MAX((case_created_date AT TIME ZONE 'America/Denver')::date) FROM stg_311)
+    ) AS ref_date
+)
 INSERT INTO mart_neighborhood_comparison (
     period, neighborhood,
     crime_rate, crash_rate, requests_311_rate,
@@ -44,6 +51,7 @@ SELECT
          ELSE NULL END,
     NOW()
 FROM ref_neighborhoods r
+CROSS JOIN data_anchor
 LEFT JOIN stg_neighborhoods n ON n.nbhd_id = r.nbhd_id
 LEFT JOIN (
     SELECT neighborhood,
@@ -51,14 +59,14 @@ LEFT JOIN (
            SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
-        SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
+        WHERE case_created_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
 ) cur ON cur.neighborhood = r.canonical_name
@@ -68,19 +76,19 @@ LEFT JOIN (
            SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
-        SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
-          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+        SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
+          AND reported_date < data_anchor.ref_date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
-          AND reported_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+        SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
+          AND reported_date < data_anchor.ref_date - %(days)s
           AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s * 2
-          AND case_created_date < (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s
+        SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
+        WHERE case_created_date >= data_anchor.ref_date - %(days)s * 2
+          AND case_created_date < data_anchor.ref_date - %(days)s
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood

--- a/data/marts/build_neighborhood_ranking.py
+++ b/data/marts/build_neighborhood_ranking.py
@@ -16,6 +16,13 @@ logger = logging.getLogger(__name__)
 
 # Two-step: first insert raw counts, then update with normalized scores and ranks
 INSERT_COUNTS_SQL = """
+WITH data_anchor AS (
+    SELECT LEAST(
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crime),
+        (SELECT MAX((reported_date AT TIME ZONE 'America/Denver')::date) FROM stg_crashes),
+        (SELECT MAX((case_created_date AT TIME ZONE 'America/Denver')::date) FROM stg_311)
+    ) AS ref_date
+)
 INSERT INTO mart_neighborhood_ranking (
     period, neighborhood,
     crime_count, crash_count, requests_311_count,
@@ -31,20 +38,21 @@ SELECT
     0,  -- placeholder
     NOW()
 FROM ref_neighborhoods n
+CROSS JOIN data_anchor
 LEFT JOIN (
     SELECT neighborhood,
            SUM(CASE WHEN src = 'crime' THEN 1 ELSE 0 END) AS crime,
            SUM(CASE WHEN src = 'crashes' THEN 1 ELSE 0 END) AS crashes,
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
-        SELECT neighborhood, 'crime' AS src FROM stg_crime
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, 'crashes' FROM stg_crashes
-        WHERE reported_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
+        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
         UNION ALL
-        SELECT neighborhood, '311' FROM stg_311
-        WHERE case_created_date >= (NOW() AT TIME ZONE 'America/Denver')::date - %(days)s AND neighborhood IS NOT NULL
+        SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
+        WHERE case_created_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
     ) all_src
     GROUP BY neighborhood
 ) c ON c.neighborhood = n.canonical_name

--- a/data/marts/tests/test_build_heatmap_signals.py
+++ b/data/marts/tests/test_build_heatmap_signals.py
@@ -35,6 +35,11 @@ class TestHeatmapSQL:
     def test_three_periods(self):
         assert len(HM_PERIODS) == 3
 
+    def test_uses_data_anchor_not_now(self):
+        # Regression: NOW() caused empty results when data lagged behind current date
+        assert "data_anchor" in HEATMAP_SQL
+        assert "NOW() AT TIME ZONE" not in HEATMAP_SQL
+
 
 class TestCategoryBreakdownSQL:
     def test_inserts_into_correct_table(self):
@@ -54,6 +59,11 @@ class TestCategoryBreakdownSQL:
 
     def test_three_periods(self):
         assert len(CAT_PERIODS) == 3
+
+    def test_uses_data_anchor_not_now(self):
+        # Regression: NOW() caused empty results when data lagged behind current date
+        assert "data_anchor" in CAT_SQL
+        assert "NOW() AT TIME ZONE" not in CAT_SQL
 
 
 class TestNarrativeSignals:

--- a/data/marts/tests/test_build_neighborhood.py
+++ b/data/marts/tests/test_build_neighborhood.py
@@ -41,6 +41,11 @@ class TestCityPulseNeighborhoodSQL:
         # Should have CASE WHEN ... > 0 to avoid div by zero
         assert "> 0" in NBHD_SQL
 
+    def test_uses_data_anchor_not_now(self):
+        # Regression: NOW() caused empty results when data lagged behind current date
+        assert "data_anchor" in NBHD_SQL
+        assert "NOW() AT TIME ZONE" not in NBHD_SQL
+
 
 class TestNeighborhoodRankingSQL:
     def test_inserts_into_correct_table(self):
@@ -63,6 +68,11 @@ class TestNeighborhoodRankingSQL:
     def test_three_periods(self):
         assert len(RANK_PERIODS) == 3
 
+    def test_uses_data_anchor_not_now(self):
+        # Regression: NOW() caused empty results when data lagged behind current date
+        assert "data_anchor" in INSERT_COUNTS_SQL
+        assert "NOW() AT TIME ZONE" not in INSERT_COUNTS_SQL
+
 
 class TestNeighborhoodComparisonSQL:
     def test_inserts_into_correct_table(self):
@@ -82,3 +92,8 @@ class TestNeighborhoodComparisonSQL:
 
     def test_three_periods(self):
         assert len(COMP_PERIODS) == 3
+
+    def test_uses_data_anchor_not_now(self):
+        # Regression: NOW() caused empty results when data lagged behind current date
+        assert "data_anchor" in COMPARISON_SQL
+        assert "NOW() AT TIME ZONE" not in COMPARISON_SQL


### PR DESCRIPTION
## Summary
- All five mart build scripts used `NOW()` to calculate time window boundaries, causing empty/incorrect data when source data lags behind the current date
- Replaced with a `data_anchor` CTE that computes `LEAST(MAX(date))` across all three staging tables
- Added regression tests to all affected test files

Closes #193

## What was broken
- **Heatmap** ("Incidents by Day & Hour") — empty on 7D filter
- **Change Leaders** — only green categories on 7D (all deltas = -100%)
- **Neighborhood Map** — 311 counts = 0 for short periods
- **Category Breakdown** / **Neighborhood Ranking** — same root cause

## Root cause
`NOW() - 7 days = Mar 10`, but data only available through Mar 9 → zero rows for 7D period.

## Fix
Each script now computes:
```sql
WITH data_anchor AS (
    SELECT LEAST(
        MAX(crime_date), MAX(crash_date), MAX(311_date)
    ) AS ref_date
)
```
So "7D" means "last 7 days of available data", not "last 7 days from now".

## Affected files
- `data/marts/build_heatmap.py`
- `data/marts/build_neighborhood_comparison.py`
- `data/marts/build_city_pulse_neighborhood.py`
- `data/marts/build_category_breakdown.py`
- `data/marts/build_neighborhood_ranking.py`
- `data/marts/tests/test_build_heatmap_signals.py` (regression tests)
- `data/marts/tests/test_build_neighborhood.py` (regression tests)

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 82 passed
- [x] `pytest data/marts/tests/` — 79 passed, 1 pre-existing failure (unrelated `shape_area` test)
- [ ] Deploy to Railway and verify heatmap/Change Leaders show data on 7D filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)