### PR TITLE
Fix: explicit Denver timezone in mart date comparisons

### DIFF
--- a/data/marts/build_category_breakdown.py
+++ b/data/marts/build_category_breakdown.py
@@ -60,7 +60,8 @@ SELECT
     {crime_label},
     COUNT(*), 0, NOW()
 FROM stg_crime CROSS JOIN data_anchor
-WHERE reported_date >= data_anchor.ref_date - %(days)s
+WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+  AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
 GROUP BY {crime_label}
 
 UNION ALL
@@ -71,7 +72,8 @@ SELECT
     {crash_label},
     COUNT(*), 0, NOW()
 FROM stg_crashes CROSS JOIN data_anchor
-WHERE reported_date >= data_anchor.ref_date - %(days)s
+WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+  AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
 GROUP BY {crash_label}
 
 UNION ALL
@@ -82,7 +84,8 @@ SELECT
     COALESCE(NULLIF(agency, ''), 'Other'),
     COUNT(*), 0, NOW()
 FROM stg_311 CROSS JOIN data_anchor
-WHERE case_created_date >= data_anchor.ref_date - %(days)s
+WHERE case_created_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+  AND case_created_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
 GROUP BY agency
 
 ON CONFLICT (period, domain, category) DO UPDATE SET

--- a/data/marts/build_city_pulse_neighborhood.py
+++ b/data/marts/build_city_pulse_neighborhood.py
@@ -65,13 +65,19 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
-        WHERE case_created_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE case_created_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND case_created_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
 ) cur ON cur.neighborhood = n.neighborhood
@@ -83,18 +89,18 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
-          AND reported_date < data_anchor.ref_date - %(days)s
+        WHERE reported_date > (data_anchor.ref_date - %(days)s * 2)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date - %(days)s + 1)::timestamp AT TIME ZONE 'America/Denver'
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
-          AND reported_date < data_anchor.ref_date - %(days)s
+        WHERE reported_date > (data_anchor.ref_date - %(days)s * 2)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date - %(days)s + 1)::timestamp AT TIME ZONE 'America/Denver'
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
-        WHERE case_created_date >= data_anchor.ref_date - %(days)s * 2
-          AND case_created_date < data_anchor.ref_date - %(days)s
+        WHERE case_created_date > (data_anchor.ref_date - %(days)s * 2)::timestamp AT TIME ZONE 'America/Denver'
+          AND case_created_date <= (data_anchor.ref_date - %(days)s + 1)::timestamp AT TIME ZONE 'America/Denver'
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood

--- a/data/marts/build_heatmap.py
+++ b/data/marts/build_heatmap.py
@@ -34,7 +34,8 @@ SELECT
     COUNT(*),
     NOW()
 FROM stg_crime CROSS JOIN data_anchor
-WHERE reported_date >= data_anchor.ref_date - %(days)s
+WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+  AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
 GROUP BY
     EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
@@ -50,7 +51,8 @@ SELECT
     COUNT(*),
     NOW()
 FROM stg_crashes CROSS JOIN data_anchor
-WHERE reported_date >= data_anchor.ref_date - %(days)s
+WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+  AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
 GROUP BY
     EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
@@ -66,7 +68,8 @@ SELECT
     COUNT(*),
     NOW()
 FROM stg_311 CROSS JOIN data_anchor
-WHERE case_created_date >= data_anchor.ref_date - %(days)s
+WHERE case_created_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+  AND case_created_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
 GROUP BY
     EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver'),
     EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')

--- a/data/marts/build_neighborhood_comparison.py
+++ b/data/marts/build_neighborhood_comparison.py
@@ -60,13 +60,19 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
-        WHERE case_created_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE case_created_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND case_created_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
     ) cur_all
     GROUP BY neighborhood
 ) cur ON cur.neighborhood = r.canonical_name
@@ -77,18 +83,18 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
-          AND reported_date < data_anchor.ref_date - %(days)s
+        WHERE reported_date > (data_anchor.ref_date - %(days)s * 2)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date - %(days)s + 1)::timestamp AT TIME ZONE 'America/Denver'
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s * 2
-          AND reported_date < data_anchor.ref_date - %(days)s
+        WHERE reported_date > (data_anchor.ref_date - %(days)s * 2)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date - %(days)s + 1)::timestamp AT TIME ZONE 'America/Denver'
           AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
-        WHERE case_created_date >= data_anchor.ref_date - %(days)s * 2
-          AND case_created_date < data_anchor.ref_date - %(days)s
+        WHERE case_created_date > (data_anchor.ref_date - %(days)s * 2)::timestamp AT TIME ZONE 'America/Denver'
+          AND case_created_date <= (data_anchor.ref_date - %(days)s + 1)::timestamp AT TIME ZONE 'America/Denver'
           AND neighborhood IS NOT NULL
     ) prev_all
     GROUP BY neighborhood

--- a/data/marts/build_neighborhood_ranking.py
+++ b/data/marts/build_neighborhood_ranking.py
@@ -46,13 +46,19 @@ LEFT JOIN (
            SUM(CASE WHEN src = '311' THEN 1 ELSE 0 END) AS r311
     FROM (
         SELECT neighborhood, 'crime' AS src FROM stg_crime CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, 'crashes' FROM stg_crashes CROSS JOIN data_anchor
-        WHERE reported_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE reported_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND reported_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
         UNION ALL
         SELECT neighborhood, '311' FROM stg_311 CROSS JOIN data_anchor
-        WHERE case_created_date >= data_anchor.ref_date - %(days)s AND neighborhood IS NOT NULL
+        WHERE case_created_date > (data_anchor.ref_date - %(days)s)::timestamp AT TIME ZONE 'America/Denver'
+          AND case_created_date <= (data_anchor.ref_date + 1)::timestamp AT TIME ZONE 'America/Denver'
+          AND neighborhood IS NOT NULL
     ) all_src
     GROUP BY neighborhood
 ) c ON c.neighborhood = n.canonical_name

--- a/data/marts/tests/test_build_heatmap_signals.py
+++ b/data/marts/tests/test_build_heatmap_signals.py
@@ -40,6 +40,18 @@ class TestHeatmapSQL:
         assert "data_anchor" in HEATMAP_SQL
         assert "NOW() AT TIME ZONE" not in HEATMAP_SQL
 
+    def test_uses_explicit_denver_timezone_in_where(self):
+        # Regression: implicit DATE→TIMESTAMPTZ cast used UTC session timezone,
+        # causing 7d period to return 0 crime/crash rows
+        assert "AT TIME ZONE 'America/Denver'" in HEATMAP_SQL
+        # Must NOT compare reported_date directly against a DATE without timezone
+        assert "reported_date >= data_anchor.ref_date" not in HEATMAP_SQL
+        assert "case_created_date >= data_anchor.ref_date" not in HEATMAP_SQL
+
+    def test_has_upper_bound_in_where(self):
+        # Each period filter must have both lower AND upper bound
+        assert "ref_date + 1" in HEATMAP_SQL
+
 
 class TestCategoryBreakdownSQL:
     def test_inserts_into_correct_table(self):
@@ -64,6 +76,12 @@ class TestCategoryBreakdownSQL:
         # Regression: NOW() caused empty results when data lagged behind current date
         assert "data_anchor" in CAT_SQL
         assert "NOW() AT TIME ZONE" not in CAT_SQL
+
+    def test_uses_explicit_denver_timezone_in_where(self):
+        # Regression: implicit DATE→TIMESTAMPTZ cast used UTC session timezone
+        assert "reported_date >= data_anchor.ref_date" not in CAT_SQL
+        assert "case_created_date >= data_anchor.ref_date" not in CAT_SQL
+        assert "ref_date + 1" in CAT_SQL
 
 
 class TestNarrativeSignals:


### PR DESCRIPTION
## Summary
- All period-based mart builds (`category_breakdown`, `heatmap`, `neighborhood`, `comparison`, `ranking`) compared `TIMESTAMPTZ >= DATE` without explicit timezone, causing PostgreSQL to use UTC session timezone instead of Denver
- Changed all WHERE clauses to use `::timestamp AT TIME ZONE 'America/Denver'` for correct Denver-midnight boundaries
- Added upper bounds (`ref_date + 1`) to properly constrain each period window
- Added regression tests verifying explicit timezone usage and upper bounds

Closes #199

## Test plan
- [x] Pipeline tests: 82/83 passed (1 pre-existing failure unrelated to this change)
- [x] Frontend tests: 90 passed
- [x] Build: successful
- [ ] Trigger pipeline re-run on Railway after merge to verify 7d data populates
- [ ] Verify heatmap and neighborhood map show data for 7D filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)