### PR TITLE
Add info tooltip to Change Leaders chart

### DIFF
--- a/__tests__/info-tooltip.test.tsx
+++ b/__tests__/info-tooltip.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { InfoTooltip } from "@/components/ui/info-tooltip";
+
+describe("InfoTooltip", () => {
+  it("renders the info button with accessible label", () => {
+    render(<InfoTooltip text="Test explanation" />);
+    expect(screen.getByRole("button", { name: "Show chart info" })).toBeInTheDocument();
+  });
+
+  it("contains the tooltip text in the DOM", () => {
+    render(<InfoTooltip text="Test explanation" />);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Test explanation");
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import { useFilters } from "@/lib/hooks/use-filters";
 import { useCityPulseData } from "@/lib/hooks/use-city-pulse-data";
 import { useEnvironmentData } from "@/lib/hooks/use-environment-data";
 import { ErrorCard } from "@/components/cards/error-card";
+import { InfoTooltip } from "@/components/ui/info-tooltip";
 import { formatAqi, formatDateRange } from "@/lib/format";
 import geojson from "@/data/geo/denver-neighborhoods.json";
 
@@ -232,7 +233,14 @@ function CityPulseContent() {
       </div>
 
       {/* Row 5: Change Leaders (full-width) */}
-      <ChartCard title="Change Leaders" subtitle={cityPulseSubtitle} loading={envLoading}>
+      <ChartCard
+        title="Change Leaders"
+        subtitle={cityPulseSubtitle}
+        loading={envLoading}
+        headerRight={
+          <InfoTooltip text="Top 5 most improved and top 5 most worsened neighborhoods. The metric is the average % change across crime, crashes, and 311 requests compared to the prior period of the same length. Counts are normalized by neighborhood area." />
+        }
+      >
         <ChangeLeadersChart data={comparison} />
       </ChartCard>
     </PageShell>

--- a/components/ui/info-tooltip.tsx
+++ b/components/ui/info-tooltip.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Info } from "lucide-react";
+
+interface InfoTooltipProps {
+  text: string;
+}
+
+export function InfoTooltip({ text }: InfoTooltipProps) {
+  return (
+    <div className="relative group">
+      <button
+        type="button"
+        aria-label="Show chart info"
+        className="flex items-center justify-center w-5 h-5 rounded-full text-[#627D98] hover:text-[#52667A] hover:bg-[#EEF3F8] transition-colors"
+      >
+        <Info size={14} strokeWidth={2} />
+      </button>
+      <div
+        role="tooltip"
+        className="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-opacity duration-150 absolute right-0 top-full mt-1.5 z-50 w-72 rounded-lg border border-[#DDE3EA] bg-white px-3 py-2.5 shadow-md text-[10px] leading-relaxed text-[#52667A] pointer-events-none"
+      >
+        {text}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a question-mark icon button (lucide `Info`) to the Change Leaders chart header
- On hover, displays a tooltip explaining the chart logic: top 5 improved / worsened neighborhoods, average % change across crime, crashes, and 311, comparison to prior period, area normalization
- Uses lightweight CSS hover approach (no new dependencies)

Closes #205

## Test plan
- [x] InfoTooltip renders button with accessible label
- [x] Tooltip text present in DOM
- [x] All existing tests pass (92/92)
- [x] Lint clean (0 errors)
- [ ] Visual check: hover over (?) icon on Change Leaders card

🤖 Generated with [Claude Code](https://claude.com/claude-code)