### PR TITLE
Fix Y-axis labels and add hover tooltip for truncated names

### DIFF
--- a/components/charts/change-leaders-chart.tsx
+++ b/components/charts/change-leaders-chart.tsx
@@ -132,12 +132,14 @@ export function ChangeLeadersChart({ data, domain }: ChangeLeadersChartProps) {
                 fontWeight={isMI ? 700 : 400}
                 dominantBaseline="central"
               >
+                <title>{value}</title>
                 {isMI ? "★ " : ""}{truncate(value, 14)}
               </text>
             );
           }}
           axisLine={false}
           tickLine={false}
+          interval={0}
         />
         <ReferenceLine x={0} stroke="#DDE3EA" />
         <Tooltip content={<CustomTooltip />} />

--- a/components/charts/neighborhood-ranking-chart.tsx
+++ b/components/charts/neighborhood-ranking-chart.tsx
@@ -144,6 +144,7 @@ export function NeighborhoodRankingChart({
                 fontWeight={isTopEntry ? 700 : 400}
                 dominantBaseline="central"
               >
+                <title>{value}</title>
                 {isTopEntry ? "▲ " : ""}
                 {truncate(value, 14)}
               </text>
@@ -151,6 +152,7 @@ export function NeighborhoodRankingChart({
           }}
           axisLine={false}
           tickLine={false}
+          interval={0}
         />
         <Tooltip content={<CustomTooltip />} />
         <Bar dataKey="count" isAnimationActive={false} radius={[4, 4, 4, 4]}>


### PR DESCRIPTION
## Summary
- Add `interval={0}` to YAxis on both ranking charts so labels appear on **every** bar, not every other one
- Add SVG `<title>` inside custom tick text for native hover tooltip showing full neighborhood name

Closes #212

## Test plan
- [ ] Open City Pulse page with neighborhood ranking data loaded
- [ ] Verify all 10 bars in Neighborhood Ranking chart have visible Y-axis labels
- [ ] Verify all 10 bars in Change Leaders chart have visible Y-axis labels
- [ ] Hover over a truncated label (e.g. "North Park Hi…") — full name should appear in tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)