### PR TITLE
Fix: match bar opacity between Category Breakdown and Neighborhood Ranking

### DIFF
--- a/components/charts/neighborhood-ranking-chart.tsx
+++ b/components/charts/neighborhood-ranking-chart.tsx
@@ -160,6 +160,7 @@ export function NeighborhoodRankingChart({
             <Cell
               key={i}
               fill={entry.isTop ? colors.strong : colors.normal}
+              opacity={0.8}
             />
           ))}
         </Bar>


### PR DESCRIPTION
## Summary
- Added `opacity: 0.8` to Neighborhood Ranking chart bars to match Category Breakdown styling
- Both charts now use the same visual treatment for domain colors

Closes #216

## Test plan
- [ ] Compare crime bar color in Category Breakdown vs Neighborhood Ranking — should look identical
- [ ] Compare crashes bar color in both charts — should look identical
- [ ] Verify top-ranked entry (▲) still uses the strong/dark color variant with opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)