### PR TITLE
Fix: neighborhood filter for categories, trends, and heatmap charts

### DIFF
--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -178,6 +178,23 @@ describe("City Pulse API", () => {
       expect(body.data.requests311).toHaveLength(1);
       expect(body.data.crime[0].category).toBe("Theft");
     });
+
+    it("passes neighborhood param to query when provided", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", category: "Theft", count: 10, pct_of_total: 100.0 },
+      ]);
+
+      const res = await getCategories(
+        makeRequest("http://localhost/api/city-pulse/categories?timeWindow=30d&neighborhood=Five%20Points")
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      // Neighborhood query hits staging tables with neighborhood filter
+      const sql = mockQuery.mock.calls[0][0] as string;
+      expect(sql).toContain("neighborhood = $2");
+      expect(mockQuery.mock.calls[0][1]).toContain("Five Points");
+    });
   });
 
   describe("GET /api/city-pulse/heatmap", () => {
@@ -191,6 +208,22 @@ describe("City Pulse API", () => {
 
       expect(res.status).toBe(200);
       expect(body.data[0]).toEqual({ dayOfWeek: 0, hourOfDay: 12, count: 45 });
+    });
+
+    it("passes neighborhood param to query when provided", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { day_of_week: 0, hour_of_day: 12, count: 5 },
+      ]);
+
+      const res = await getHeatmap(
+        makeRequest("http://localhost/api/city-pulse/heatmap?timeWindow=30d&domain=crime&neighborhood=Capitol%20Hill")
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      const sql = mockQuery.mock.calls[0][0] as string;
+      expect(sql).toContain("neighborhood = $2");
+      expect(mockQuery.mock.calls[0][1]).toContain("Capitol Hill");
     });
   });
 
@@ -234,6 +267,22 @@ describe("City Pulse API", () => {
       expect(body.data.crime.Theft[0]).toEqual({ date: "2026-03-10", value: 12 });
       expect(body.data.crime.Assault).toHaveLength(1);
       expect(body.data.requests311.Graffiti).toHaveLength(1);
+    });
+
+    it("passes neighborhood param to query when provided", async () => {
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", category: "Theft", date: "2026-03-10", count: 3 },
+      ]);
+
+      const res = await getCategoryTrends(
+        makeRequest("http://localhost/api/city-pulse/category-trends?timeWindow=7d&neighborhood=LoDo")
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      const sql = mockQuery.mock.calls[0][0] as string;
+      expect(sql).toContain("neighborhood = $2");
+      expect(mockQuery.mock.calls[0][1]).toContain("LoDo");
     });
 
     it("returns 500 on error", async () => {

--- a/app/api/city-pulse/categories/route.ts
+++ b/app/api/city-pulse/categories/route.ts
@@ -7,7 +7,8 @@ export const dynamic = "force-dynamic";
 export async function GET(request: NextRequest) {
   try {
     const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
-    const rows = await getCategories(tw);
+    const neighborhood = request.nextUrl.searchParams.get("neighborhood") ?? "all";
+    const rows = await getCategories(tw, neighborhood);
 
     const grouped: Record<string, { category: string; count: number; percent: number }[]> = {
       crime: [],

--- a/app/api/city-pulse/category-trends/route.ts
+++ b/app/api/city-pulse/category-trends/route.ts
@@ -7,7 +7,8 @@ export const dynamic = "force-dynamic";
 export async function GET(request: NextRequest) {
   try {
     const tw = (request.nextUrl.searchParams.get("timeWindow") ?? "30d") as TimeWindow;
-    const rows = await getCategoryTrends(tw);
+    const neighborhood = request.nextUrl.searchParams.get("neighborhood") ?? "all";
+    const rows = await getCategoryTrends(tw, neighborhood);
 
     // Group: domain → category → ChartPoint[]
     const grouped: Record<string, Record<string, ChartPoint[]>> = {};

--- a/app/api/city-pulse/heatmap/route.ts
+++ b/app/api/city-pulse/heatmap/route.ts
@@ -10,7 +10,8 @@ export async function GET(request: NextRequest) {
     const tw = (params.get("timeWindow") ?? "30d") as TimeWindow;
     const domain = params.get("domain") ?? "all";
 
-    const rows = await getHeatmap(tw, domain);
+    const neighborhood = params.get("neighborhood") ?? "all";
+    const rows = await getHeatmap(tw, domain, neighborhood);
     const data = rows.map((r) => ({
       dayOfWeek: r.day_of_week,
       hourOfDay: r.hour_of_day,

--- a/lib/hooks/use-city-pulse-data.ts
+++ b/lib/hooks/use-city-pulse-data.ts
@@ -69,10 +69,10 @@ export function useCityPulseData(
           `/api/city-pulse/categories?${qs}`
         ),
         fetchJson<CategoryTrends>(
-          `/api/city-pulse/category-trends?timeWindow=${timeWindow}`
+          `/api/city-pulse/category-trends?${qs}`
         ),
-        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?timeWindow=${timeWindow}&domain=crime`),
-        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?timeWindow=${timeWindow}&domain=crashes`),
+        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?${qs}&domain=crime`),
+        fetchJson<HeatmapCell[]>(`/api/city-pulse/heatmap?${qs}&domain=crashes`),
         fetchJson<NeighborhoodRow[]>(
           `/api/city-pulse/neighborhoods?timeWindow=${timeWindow}`
         ),

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -5,6 +5,31 @@ function daysForWindow(tw: TimeWindow): number {
   return tw === "7d" ? 7 : tw === "30d" ? 30 : 90;
 }
 
+// Category label SQL fragments — must match data/marts/build_category_breakdown.py
+const CRIME_LABEL_SQL = `
+  CASE COALESCE(offense_category, 'unknown')
+    WHEN 'all-other-crimes'        THEN 'Other'
+    WHEN 'theft-from-motor-vehicle' THEN 'Vehicle Theft'
+    WHEN 'white-collar-crime'       THEN 'White-Collar Crime'
+    WHEN 'murder'                   THEN 'Homicide'
+    ELSE INITCAP(REPLACE(COALESCE(offense_category, 'Unknown'), '-', ' '))
+  END`;
+
+const CRASH_LABEL_SQL = `
+  CASE TRIM(COALESCE(top_offense, 'Unknown'))
+    WHEN 'TRAF - ACCIDENT'             THEN 'Traffic Accident'
+    WHEN 'TRAF - ACCIDENT - HIT & RUN' THEN 'Hit & Run'
+    WHEN 'TRAF - ACCIDENT - DUI/DUID'  THEN 'DUI / DUID'
+    WHEN 'TRAF - ACCIDENT - SBI'       THEN 'Serious Bodily Injury'
+    WHEN 'TRAF - ACCIDENT - POLICE'    THEN 'Police Involved'
+    WHEN 'TRAF - ACCIDENT - FATAL'     THEN 'Fatal Crash'
+    WHEN 'TRAF - HABITUAL OFFENDER'    THEN 'Habitual Offender'
+    ELSE INITCAP(REPLACE(
+      REPLACE(TRIM(COALESCE(top_offense, 'Unknown')), 'TRAF - ACCIDENT - ', ''),
+      '-', ' '
+    ))
+  END`;
+
 // --- KPIs ---
 
 interface DailyRow {
@@ -312,30 +337,121 @@ interface CategoryTrendRow {
 }
 
 export async function getCategoryTrends(
-  tw: TimeWindow
+  tw: TimeWindow,
+  neighborhood: string = "all"
 ): Promise<CategoryTrendRow[]> {
   const days = daysForWindow(tw);
-  if (days <= 30) {
+  if (neighborhood === "all") {
+    if (days <= 30) {
+      return query<CategoryTrendRow>(
+        `SELECT domain, category, date::text, count
+         FROM mart_incident_trends
+         WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
+           AND date <= (SELECT MAX(date) FROM mart_incident_trends)
+         ORDER BY domain, category, date`,
+        [days]
+      );
+    }
     return query<CategoryTrendRow>(
-      `SELECT domain, category, date::text, count
+      `SELECT domain, category,
+              DATE_TRUNC('week', date)::date::text AS date,
+              SUM(count)::int AS count
        FROM mart_incident_trends
        WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
          AND date <= (SELECT MAX(date) FROM mart_incident_trends)
+       GROUP BY domain, category, DATE_TRUNC('week', date)
        ORDER BY domain, category, date`,
       [days]
     );
   }
-  // 90d: aggregate by week for cleaner sparklines
+  // For neighborhood: query staging tables, optional weekly aggregation for 90d
+  if (days <= 30) {
+    return query<CategoryTrendRow>(
+      `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily)
+       SELECT domain, category, date, count FROM (
+         SELECT 'crime' AS domain,
+                ${CRIME_LABEL_SQL} AS category,
+                (reported_date AT TIME ZONE 'America/Denver')::date::text AS date,
+                COUNT(*)::int AS count
+         FROM stg_crime CROSS JOIN anchor
+         WHERE neighborhood = $2
+           AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+           AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+         GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, ${CRIME_LABEL_SQL}
+
+         UNION ALL
+
+         SELECT 'crashes' AS domain,
+                ${CRASH_LABEL_SQL} AS category,
+                (reported_date AT TIME ZONE 'America/Denver')::date::text AS date,
+                COUNT(*)::int AS count
+         FROM stg_crashes CROSS JOIN anchor
+         WHERE neighborhood = $2
+           AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+           AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+         GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, ${CRASH_LABEL_SQL}
+
+         UNION ALL
+
+         SELECT '311' AS domain,
+                COALESCE(NULLIF(agency, ''), 'Other') AS category,
+                (case_created_date AT TIME ZONE 'America/Denver')::date::text AS date,
+                COUNT(*)::int AS count
+         FROM stg_311 CROSS JOIN anchor
+         WHERE neighborhood = $2
+           AND case_created_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+           AND case_created_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+         GROUP BY (case_created_date AT TIME ZONE 'America/Denver')::date, agency
+       ) t
+       ORDER BY domain, category, date`,
+      [days, neighborhood]
+    );
+  }
+  // 90d + neighborhood: aggregate by week
   return query<CategoryTrendRow>(
-    `SELECT domain, category,
+    `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily),
+     daily AS (
+       SELECT 'crime' AS domain,
+              ${CRIME_LABEL_SQL} AS category,
+              (reported_date AT TIME ZONE 'America/Denver')::date AS date,
+              COUNT(*)::int AS count
+       FROM stg_crime CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, ${CRIME_LABEL_SQL}
+
+       UNION ALL
+
+       SELECT 'crashes' AS domain,
+              ${CRASH_LABEL_SQL} AS category,
+              (reported_date AT TIME ZONE 'America/Denver')::date AS date,
+              COUNT(*)::int AS count
+       FROM stg_crashes CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY (reported_date AT TIME ZONE 'America/Denver')::date, ${CRASH_LABEL_SQL}
+
+       UNION ALL
+
+       SELECT '311' AS domain,
+              COALESCE(NULLIF(agency, ''), 'Other') AS category,
+              (case_created_date AT TIME ZONE 'America/Denver')::date AS date,
+              COUNT(*)::int AS count
+       FROM stg_311 CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND case_created_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND case_created_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY (case_created_date AT TIME ZONE 'America/Denver')::date, agency
+     )
+     SELECT domain, category,
             DATE_TRUNC('week', date)::date::text AS date,
             SUM(count)::int AS count
-     FROM mart_incident_trends
-     WHERE date > (SELECT MAX(date) FROM mart_incident_trends) - $1::int
-       AND date <= (SELECT MAX(date) FROM mart_incident_trends)
+     FROM daily
      GROUP BY domain, category, DATE_TRUNC('week', date)
      ORDER BY domain, category, date`,
-    [days]
+    [days, neighborhood]
   );
 }
 
@@ -348,13 +464,59 @@ interface CategoryRow {
   pct_of_total: number;
 }
 
-export async function getCategories(tw: TimeWindow): Promise<CategoryRow[]> {
+export async function getCategories(tw: TimeWindow, neighborhood: string = "all"): Promise<CategoryRow[]> {
+  if (neighborhood === "all") {
+    return query<CategoryRow>(
+      `SELECT domain, category, count, pct_of_total
+       FROM mart_category_breakdown
+       WHERE period = $1
+       ORDER BY domain, count DESC`,
+      [tw]
+    );
+  }
+  const days = daysForWindow(tw);
   return query<CategoryRow>(
-    `SELECT domain, category, count, pct_of_total
-     FROM mart_category_breakdown
-     WHERE period = $1
-     ORDER BY domain, count DESC`,
-    [tw]
+    `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily),
+     raw AS (
+       SELECT 'crime' AS domain,
+              ${CRIME_LABEL_SQL} AS category,
+              COUNT(*)::int AS count
+       FROM stg_crime CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY ${CRIME_LABEL_SQL}
+
+       UNION ALL
+
+       SELECT 'crashes' AS domain,
+              ${CRASH_LABEL_SQL} AS category,
+              COUNT(*)::int AS count
+       FROM stg_crashes CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY ${CRASH_LABEL_SQL}
+
+       UNION ALL
+
+       SELECT '311' AS domain,
+              COALESCE(NULLIF(agency, ''), 'Other') AS category,
+              COUNT(*)::int AS count
+       FROM stg_311 CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND case_created_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND case_created_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY agency
+     ),
+     totals AS (
+       SELECT domain, SUM(count) AS total FROM raw GROUP BY domain
+     )
+     SELECT raw.domain, raw.category, raw.count,
+            ROUND(raw.count::numeric / NULLIF(totals.total, 0) * 100, 1) AS pct_of_total
+     FROM raw JOIN totals ON raw.domain = totals.domain
+     ORDER BY raw.domain, raw.count DESC`,
+    [days, neighborhood]
   );
 }
 
@@ -368,24 +530,105 @@ interface HeatmapRow {
 
 export async function getHeatmap(
   tw: TimeWindow,
-  domain: string
+  domain: string,
+  neighborhood: string = "all"
 ): Promise<HeatmapRow[]> {
-  if (domain === "all") {
+  if (neighborhood === "all") {
+    if (domain === "all") {
+      return query<HeatmapRow>(
+        `SELECT day_of_week, hour_of_day, ROUND(AVG(count))::int AS count
+         FROM mart_heatmap_hour_day
+         WHERE period = $1
+         GROUP BY day_of_week, hour_of_day
+         ORDER BY day_of_week, hour_of_day`,
+        [tw]
+      );
+    }
     return query<HeatmapRow>(
-      `SELECT day_of_week, hour_of_day, ROUND(AVG(count))::int AS count
+      `SELECT day_of_week, hour_of_day, count
        FROM mart_heatmap_hour_day
-       WHERE period = $1
-       GROUP BY day_of_week, hour_of_day
+       WHERE period = $1 AND domain = $2
        ORDER BY day_of_week, hour_of_day`,
-      [tw]
+      [tw, domain]
     );
   }
+  // Neighborhood-specific: query staging tables directly
+  const days = daysForWindow(tw);
+  if (domain === "crime") {
+    return query<HeatmapRow>(
+      `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily)
+       SELECT EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver')::smallint - 1 AS day_of_week,
+              EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint AS hour_of_day,
+              COUNT(*)::int AS count
+       FROM stg_crime CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
+                EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
+       ORDER BY day_of_week, hour_of_day`,
+      [days, neighborhood]
+    );
+  }
+  if (domain === "crashes") {
+    return query<HeatmapRow>(
+      `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily)
+       SELECT EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver')::smallint - 1 AS day_of_week,
+              EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint AS hour_of_day,
+              COUNT(*)::int AS count
+       FROM stg_crashes CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
+                EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
+       ORDER BY day_of_week, hour_of_day`,
+      [days, neighborhood]
+    );
+  }
+  // domain === "all": union all three, then AVG across domains
   return query<HeatmapRow>(
-    `SELECT day_of_week, hour_of_day, count
-     FROM mart_heatmap_hour_day
-     WHERE period = $1 AND domain = $2
+    `WITH anchor AS (SELECT MAX(date) AS d FROM mart_city_pulse_daily),
+     per_domain AS (
+       SELECT EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver')::smallint - 1 AS day_of_week,
+              EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint AS hour_of_day,
+              COUNT(*)::int AS count
+       FROM stg_crime CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
+                EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
+
+       UNION ALL
+
+       SELECT EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver')::smallint - 1,
+              EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')::smallint,
+              COUNT(*)::int
+       FROM stg_crashes CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND reported_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND reported_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY EXTRACT(ISODOW FROM reported_date AT TIME ZONE 'America/Denver'),
+                EXTRACT(HOUR FROM reported_date AT TIME ZONE 'America/Denver')
+
+       UNION ALL
+
+       SELECT EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver')::smallint - 1,
+              EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')::smallint,
+              COUNT(*)::int
+       FROM stg_311 CROSS JOIN anchor
+       WHERE neighborhood = $2
+         AND case_created_date > (anchor.d - $1::int)::timestamp AT TIME ZONE 'America/Denver'
+         AND case_created_date <= (anchor.d + 1)::timestamp AT TIME ZONE 'America/Denver'
+       GROUP BY EXTRACT(ISODOW FROM case_created_date AT TIME ZONE 'America/Denver'),
+                EXTRACT(HOUR FROM case_created_date AT TIME ZONE 'America/Denver')
+     )
+     SELECT day_of_week, hour_of_day, ROUND(AVG(count))::int AS count
+     FROM per_domain
+     GROUP BY day_of_week, hour_of_day
      ORDER BY day_of_week, hour_of_day`,
-    [tw, domain]
+    [days, neighborhood]
   );
 }
 


### PR DESCRIPTION
## Summary
- Neighborhood filter was ignored by Category Breakdown, Category Trends (sparklines), and Incidents by Day & Hour (heatmap) charts — they always showed city-wide data
- When `neighborhood ≠ "all"`, queries now hit staging tables (`stg_crime`, `stg_crashes`, `stg_311`) directly with a `WHERE neighborhood = $N` filter, matching the pattern already used by KPI sparklines
- When `neighborhood = "all"`, pre-aggregated mart tables are still used (no performance change)

## Changes
- `lib/queries/city-pulse.ts` — added `neighborhood` parameter to `getCategories()`, `getCategoryTrends()`, `getHeatmap()` with staging-table query branches
- `app/api/city-pulse/categories/route.ts` — extract `neighborhood` from query string
- `app/api/city-pulse/category-trends/route.ts` — extract `neighborhood` from query string
- `app/api/city-pulse/heatmap/route.ts` — extract `neighborhood` from query string
- `lib/hooks/use-city-pulse-data.ts` — pass `qs` (with neighborhood) to category-trends and heatmap fetch calls

Closes #218

## Test plan
- [x] 3 regression tests added (one per affected API route) verifying neighborhood param is passed to SQL
- [x] All 105 tests pass
- [x] Lint clean, build succeeds
- [ ] Manual: select a neighborhood → verify Category Breakdown, sparklines, and heatmap reflect filtered data
- [ ] Manual: select "All Neighborhoods" → verify charts show city-wide data (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)