### PR TITLE
Fix: dashboard crash on neighborhood filter (closes #220)

### DIFF
--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -195,6 +195,27 @@ describe("City Pulse API", () => {
       expect(sql).toContain("neighborhood = $2");
       expect(mockQuery.mock.calls[0][1]).toContain("Five Points");
     });
+
+    it("returns percent as number even when pg returns numeric as string (closes #220)", async () => {
+      // PostgreSQL ROUND() returns numeric type, which pg driver serializes as string
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", category: "Larceny", count: "118", pct_of_total: "44.2" },
+        { domain: "crashes", category: "Hit & Run", count: "15", pct_of_total: "60.0" },
+      ]);
+
+      const res = await getCategories(
+        makeRequest("http://localhost/api/city-pulse/categories?timeWindow=30d&neighborhood=Central%20Park")
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(typeof body.data.crime[0].percent).toBe("number");
+      expect(body.data.crime[0].percent).toBe(44.2);
+      expect(typeof body.data.crime[0].count).toBe("number");
+      expect(body.data.crime[0].count).toBe(118);
+      expect(typeof body.data.crashes[0].percent).toBe("number");
+      expect(body.data.crashes[0].percent).toBe(60.0);
+    });
   });
 
   describe("GET /api/city-pulse/heatmap", () => {

--- a/app/api/city-pulse/categories/route.ts
+++ b/app/api/city-pulse/categories/route.ts
@@ -21,8 +21,8 @@ export async function GET(request: NextRequest) {
       if (key in grouped) {
         grouped[key].push({
           category: r.category,
-          count: r.count,
-          percent: r.pct_of_total,
+          count: Number(r.count),
+          percent: Number(r.pct_of_total),
         });
       }
     }


### PR DESCRIPTION
## Summary
- Dashboard crashed with `TypeError` when any neighborhood was selected from the filter dropdown
- **Root cause**: PostgreSQL `ROUND()` returns `numeric` type, which the `pg` driver serializes as a **string** (e.g. `"44.2"`). The `CategoryChart` component called `.toFixed()` on this string value, causing the crash
- **Fix**: Cast `count` and `pct_of_total` to `Number()` in the categories API route before returning to the client
- Added regression test that verifies numeric types are returned even when `pg` returns strings

## Test plan
- [x] Regression test: `percent` and `count` are always numbers even when pg returns strings
- [x] All 104 tests pass
- [x] Lint clean
- [x] Verified via dev server: `GET /api/city-pulse/categories?neighborhood=Central%20Park` returns `percent: 44.2` (float, not string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)