### PR TITLE
feat: source vs DB freshness check with hard fail and UI

### DIFF
--- a/__tests__/api-city-pulse.test.ts
+++ b/__tests__/api-city-pulse.test.ts
@@ -51,12 +51,14 @@ describe("City Pulse API", () => {
 
   describe("GET /api/city-pulse/kpis", () => {
     it("returns KPI data with correct shape", async () => {
-      // getDomainFreshness query (called first)
+      // getDomainFreshness query (runs in Promise.all with source freshness)
       mockQuery.mockResolvedValueOnce([
         { domain: "crime", max_date: "2026-03-12" },
         { domain: "crashes", max_date: "2026-03-12" },
         { domain: "311", max_date: "2026-03-12" },
       ]);
+      // getSourceFreshness query (runs in Promise.all with domain freshness)
+      mockQuery.mockResolvedValueOnce([]);
       // sparkline query (now uses explicit date bounds)
       mockQuery.mockResolvedValueOnce([
         { date: "2026-03-12", crime_count: 10, crash_count: 5, requests_311_count: 20 },
@@ -93,6 +95,8 @@ describe("City Pulse API", () => {
         { domain: "crashes", max_date: "2026-03-09" },
         { domain: "311", max_date: "2026-03-14" },
       ]);
+      // getSourceFreshness query
+      mockQuery.mockResolvedValueOnce([]);
       // sparkline query (covers full range: Mar 3 – Mar 14)
       mockQuery.mockResolvedValueOnce([
         { date: "2026-03-03", crime_count: 5, crash_count: 2, requests_311_count: 0 },
@@ -140,6 +144,8 @@ describe("City Pulse API", () => {
         { domain: "crashes", max_date: "2026-03-01" },
         { domain: "311", max_date: "2026-03-01" },
       ]);
+      // getSourceFreshness
+      mockQuery.mockResolvedValueOnce([]);
       // sparkline (with explicit date bounds)
       mockQuery.mockResolvedValueOnce([
         { date: "2026-03-01", crime_count: 5, crash_count: 2, requests_311_count: 10 },
@@ -156,10 +162,89 @@ describe("City Pulse API", () => {
       expect(freshSql).toContain("MAX(date)");
       expect(freshSql).not.toContain("NOW()");
 
-      // sparkline query (2nd call) uses explicit date bounds when all dates are equal
-      const sparkSql = mockQuery.mock.calls[1][0] as string;
+      // getSourceFreshness query (2nd call) should read from pipeline_source_freshness
+      const sourceSql = mockQuery.mock.calls[1][0] as string;
+      expect(sourceSql).toContain("pipeline_source_freshness");
+
+      // sparkline query (3rd call) uses explicit date bounds when all dates are equal
+      const sparkSql = mockQuery.mock.calls[2][0] as string;
       expect(sparkSql).toContain("date");
       expect(sparkSql).not.toContain("NOW()");
+    });
+
+    it("includes sourceFreshness array in response", async () => {
+      // getDomainFreshness
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", max_date: "2026-04-02" },
+        { domain: "crashes", max_date: "2026-03-09" },
+        { domain: "311", max_date: "2026-03-31" },
+      ]);
+      // getSourceFreshness — include crashes as source_lag (the crashes scenario)
+      mockQuery.mockResolvedValueOnce([
+        {
+          source: "crashes",
+          source_max_date: "2026-03-09",
+          db_max_date: "2026-03-09",
+          drift_days: 0,
+          source_age_days: 27,
+          status: "source_lag",
+          checked_at: "2026-04-05T06:00:00.000Z",
+        },
+        {
+          source: "crime",
+          source_max_date: "2026-04-02",
+          db_max_date: "2026-04-02",
+          drift_days: 0,
+          source_age_days: 3,
+          status: "ok",
+          checked_at: "2026-04-05T06:00:00.000Z",
+        },
+      ]);
+      // sparkline
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-03-09", crime_count: 1, crash_count: 1, requests_311_count: 1 },
+      ]);
+      // totals
+      mockQuery.mockResolvedValueOnce([
+        { crime_count: 10, crash_count: 10, requests_311_count: 10, crime_delta_pct: 0, crash_delta_pct: 0, requests_311_delta_pct: 0 },
+      ]);
+
+      const res = await getKpis(makeRequest("http://localhost/api/city-pulse/kpis?timeWindow=7d"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.sourceFreshness).toBeDefined();
+      expect(Array.isArray(body.sourceFreshness)).toBe(true);
+      expect(body.sourceFreshness).toHaveLength(2);
+
+      const crashesEntry = body.sourceFreshness.find((s: { source: string }) => s.source === "crashes");
+      expect(crashesEntry).toBeDefined();
+      expect(crashesEntry.status).toBe("source_lag");
+      expect(crashesEntry.sourceAgeDays).toBe(27);
+      expect(crashesEntry.driftDays).toBe(0);
+    });
+
+    it("returns empty sourceFreshness array when table is missing", async () => {
+      // getDomainFreshness
+      mockQuery.mockResolvedValueOnce([
+        { domain: "crime", max_date: "2026-04-02" },
+      ]);
+      // getSourceFreshness — simulate table missing (DB throws)
+      mockQuery.mockRejectedValueOnce(new Error('relation "pipeline_source_freshness" does not exist'));
+      // sparkline
+      mockQuery.mockResolvedValueOnce([
+        { date: "2026-04-02", crime_count: 1, crash_count: 0, requests_311_count: 0 },
+      ]);
+      // totals
+      mockQuery.mockResolvedValueOnce([
+        { crime_count: 1, crash_count: 0, requests_311_count: 0, crime_delta_pct: null, crash_delta_pct: null, requests_311_delta_pct: null },
+      ]);
+
+      const res = await getKpis(makeRequest("http://localhost/api/city-pulse/kpis?timeWindow=7d"));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.sourceFreshness).toEqual([]);
     });
   });
 

--- a/__tests__/header.test.tsx
+++ b/__tests__/header.test.tsx
@@ -82,4 +82,110 @@ describe("Header freshness display", () => {
     expect(screen.queryByText(/Pipeline ran:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Data through:/)).not.toBeInTheDocument();
   });
+
+  it("renders pipeline_behind tooltip content for stale pipeline source", () => {
+    render(
+      <Header
+        title="City Pulse"
+        lastUpdated="2026-04-05T06:00:00.000Z"
+        domainFreshness={{
+          crime: "2026-03-26",
+          crashes: "2026-03-09",
+          requests311: "2026-03-31",
+          aqi: "2026-04-04",
+        }}
+        sourceFreshness={[
+          {
+            source: "crime",
+            dbDate: "2026-03-26",
+            sourceDate: "2026-04-02",
+            driftDays: 7,
+            sourceAgeDays: 3,
+            status: "pipeline_behind",
+            checkedAt: "2026-04-05T06:00:00.000Z",
+          },
+        ]}
+      />
+    );
+
+    // Tooltip body is rendered in DOM (hidden via CSS group-hover, but JSDOM
+    // still sees it). Check for pipeline_behind specific content.
+    expect(screen.getByText(/Pipeline behind by 7 days/)).toBeInTheDocument();
+  });
+
+  it("renders source_lag tooltip content when source itself is delayed", () => {
+    render(
+      <Header
+        title="City Pulse"
+        lastUpdated="2026-04-05T06:00:00.000Z"
+        domainFreshness={{
+          crime: "2026-04-02",
+          crashes: "2026-03-09",
+          requests311: "2026-03-31",
+          aqi: "2026-04-04",
+        }}
+        sourceFreshness={[
+          {
+            source: "crashes",
+            dbDate: "2026-03-09",
+            sourceDate: "2026-03-09",
+            driftDays: 0,
+            sourceAgeDays: 27,
+            status: "source_lag",
+            checkedAt: "2026-04-05T06:00:00.000Z",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/Source publishes with 27d delay/)).toBeInTheDocument();
+  });
+
+  it("renders ok tooltip content when everything is caught up", () => {
+    render(
+      <Header
+        title="City Pulse"
+        lastUpdated="2026-04-05T06:00:00.000Z"
+        domainFreshness={{
+          crime: "2026-04-02",
+          crashes: null,
+          requests311: null,
+          aqi: null,
+        }}
+        sourceFreshness={[
+          {
+            source: "crime",
+            dbDate: "2026-04-02",
+            sourceDate: "2026-04-02",
+            driftDays: 0,
+            sourceAgeDays: 3,
+            status: "ok",
+            checkedAt: "2026-04-05T06:00:00.000Z",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/Up to date/)).toBeInTheDocument();
+  });
+
+  it("renders without tooltip when sourceFreshness is omitted", () => {
+    render(
+      <Header
+        title="City Pulse"
+        lastUpdated="2026-04-05T06:00:00.000Z"
+        domainFreshness={{
+          crime: "2026-04-02",
+          crashes: null,
+          requests311: null,
+          aqi: null,
+        }}
+      />
+    );
+
+    // Only the date itself is visible — no status strings
+    expect(screen.queryByText(/Up to date/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Pipeline behind/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Source publishes with/)).not.toBeInTheDocument();
+  });
 });

--- a/app/api/city-pulse/kpis/route.ts
+++ b/app/api/city-pulse/kpis/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getKpiSparkline, getKpiTotals, getKpiTotalsPerDomain, getDomainFreshness } from "@/lib/queries/city-pulse";
+import { getKpiSparkline, getKpiTotals, getKpiTotalsPerDomain, getDomainFreshness, getSourceFreshness } from "@/lib/queries/city-pulse";
 import type { TimeWindow } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -31,7 +31,10 @@ export async function GET(request: NextRequest) {
     }
 
     const days = daysForWindow(tw);
-    const domainFreshness = await getDomainFreshness();
+    const [domainFreshness, sourceFreshness] = await Promise.all([
+      getDomainFreshness(),
+      getSourceFreshness(),
+    ]);
     const dates = [domainFreshness.crime, domainFreshness.crashes, domainFreshness.requests311].filter(Boolean) as string[];
     const effectiveThrough = dates.length > 0 ? dates.reduce((a, b) => (a < b ? a : b)) : null;
 
@@ -99,6 +102,7 @@ export async function GET(request: NextRequest) {
       lastUpdated: new Date().toISOString(),
       effectiveThrough,
       domainFreshness,
+      sourceFreshness,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ function CityPulseContent() {
   const [heatmapDomain, setHeatmapDomain] = useState<IncidentDomain>("crime");
   const [mapDomain, setMapDomain] = useState<IncidentDomain>("crime");
   const [bottomRowDomain, setBottomRowDomain] = useState<IncidentDomain>("crime");
-  const { kpis, categories, categoryTrends, heatmapCrime, heatmapCrashes, neighborhoods, loading, error, retry, domainFreshness, lastUpdated } =
+  const { kpis, categories, categoryTrends, heatmapCrime, heatmapCrashes, neighborhoods, loading, error, retry, domainFreshness, sourceFreshness, lastUpdated } =
     useCityPulseData(timeWindow, neighborhood);
   const { aqi, comparison, loading: envLoading, error: envError, retry: envRetry, effectiveThrough: envEffectiveThrough, aqiDateRange } =
     useEnvironmentData(timeWindow, neighborhood);
@@ -125,6 +125,7 @@ function CityPulseContent() {
       subtitle="Crime, crashes, 311 requests, and air quality across Denver"
       lastUpdated={lastUpdated}
       domainFreshness={fullFreshness}
+      sourceFreshness={sourceFreshness}
     >
       {/* Row 1: KPI Strip — 4 cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-3">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -4,14 +4,15 @@ import { Suspense } from "react";
 import { TimeWindowFilter } from "./time-window-filter";
 import { NeighborhoodFilter } from "./neighborhood-filter";
 import { useFilters } from "@/lib/hooks/use-filters";
-import { formatDateShort } from "@/lib/format";
-import type { DomainFreshness } from "@/lib/types";
+import { formatDate, formatDateShort } from "@/lib/format";
+import type { DomainFreshness, FreshnessSourceKey, SourceFreshness } from "@/lib/types";
 
 interface HeaderProps {
   title: string;
   subtitle?: string;
   lastUpdated?: string | null;
   domainFreshness?: DomainFreshness | null;
+  sourceFreshness?: SourceFreshness[];
 }
 
 function formatPipelineDate(iso: string): string {
@@ -27,18 +28,118 @@ function formatPipelineDate(iso: string): string {
   }) + " UTC";
 }
 
-const DOMAIN_LABELS: { key: keyof DomainFreshness; label: string }[] = [
-  { key: "crime", label: "Crime" },
-  { key: "crashes", label: "Crashes" },
-  { key: "requests311", label: "311" },
-  { key: "aqi", label: "AQI" },
+const DOMAIN_LABELS: { key: keyof DomainFreshness; label: string; sourceKey: FreshnessSourceKey }[] = [
+  { key: "crime", label: "Crime", sourceKey: "crime" },
+  { key: "crashes", label: "Crashes", sourceKey: "crashes" },
+  { key: "requests311", label: "311", sourceKey: "requests311" },
+  { key: "aqi", label: "AQI", sourceKey: "aqi" },
 ];
 
-function HeaderInner({ lastUpdated, domainFreshness }: HeaderProps) {
+function DomainFreshnessItem({
+  label,
+  dbDate,
+  freshness,
+}: {
+  label: string;
+  dbDate: string;
+  freshness: SourceFreshness | undefined;
+}) {
+  const status = freshness?.status ?? "unknown";
+  const hasTooltip = freshness != null;
+
+  // Indicator glyph next to the label — silent when everything is fine,
+  // info dot when the source itself lags, warning when our pipeline is behind.
+  const indicator = (() => {
+    if (status === "pipeline_behind") {
+      return (
+        <span
+          aria-label="Pipeline behind upstream source"
+          className="ml-0.5 inline-block w-1.5 h-1.5 rounded-full bg-[#D97904] align-middle"
+        />
+      );
+    }
+    if (status === "source_lag") {
+      return (
+        <span
+          aria-label="Upstream source publishes with delay"
+          className="ml-0.5 inline-block w-1.5 h-1.5 rounded-full bg-[#9FB3C8] align-middle"
+        />
+      );
+    }
+    return null;
+  })();
+
+  const tooltipBody = (() => {
+    if (!freshness) return null;
+
+    const dbLine = `In DB: ${formatDate(freshness.dbDate)}`;
+    const sourceLine = `At source: ${formatDate(freshness.sourceDate)}`;
+
+    let statusLine: React.ReactNode = null;
+    if (status === "ok") {
+      statusLine = (
+        <span className="text-[#198754]">✓ Up to date</span>
+      );
+    } else if (status === "source_lag") {
+      const age = freshness.sourceAgeDays;
+      statusLine = (
+        <span className="text-[#627D98]">
+          ⓘ Source publishes with {age != null ? `${age}d` : "a"} delay — pipeline is fine
+        </span>
+      );
+    } else if (status === "pipeline_behind") {
+      const drift = freshness.driftDays;
+      statusLine = (
+        <span className="text-[#D97904] font-semibold">
+          ⚠ Pipeline behind by {drift != null ? `${drift} days` : "several days"}
+        </span>
+      );
+    } else {
+      statusLine = (
+        <span className="text-[#9FB3C8]">Freshness check pending</span>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-0.5">
+        <div className="font-semibold text-[#334E68]">{label}</div>
+        <div>{dbLine}</div>
+        <div>{sourceLine}</div>
+        <div className="mt-0.5">{statusLine}</div>
+      </div>
+    );
+  })();
+
+  return (
+    <span className="relative group inline-flex items-center">
+      <span>
+        {label}{" "}
+        <span className="font-semibold text-[#627D98]">{formatDateShort(dbDate)}</span>
+        {indicator}
+      </span>
+      {hasTooltip && (
+        <div
+          role="tooltip"
+          className="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-opacity duration-150 absolute left-0 top-full mt-1.5 z-[800] w-60 rounded-lg border border-[#DDE3EA] bg-white px-3 py-2 shadow-md text-[10px] leading-relaxed text-[#52667A] pointer-events-none"
+        >
+          {tooltipBody}
+        </div>
+      )}
+    </span>
+  );
+}
+
+function HeaderInner({ lastUpdated, domainFreshness, sourceFreshness }: HeaderProps) {
   const { timeWindow, neighborhood, setTimeWindow, setNeighborhood } =
     useFilters();
 
   const hasFreshness = domainFreshness && DOMAIN_LABELS.some((d) => domainFreshness[d.key]);
+
+  // Index sourceFreshness by source key for O(1) lookup in the render loop
+  const freshnessBySource = new Map<FreshnessSourceKey, SourceFreshness>();
+  for (const f of sourceFreshness ?? []) {
+    freshnessBySource.set(f.source, f);
+  }
 
   return (
     <header className="sticky top-0 z-[700] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-4 px-3 py-3 md:px-4 xl:px-5 bg-white border-b border-[#E6E9EE]">
@@ -58,8 +159,11 @@ function HeaderInner({ lastUpdated, domainFreshness }: HeaderProps) {
                     .filter((d) => domainFreshness![d.key])
                     .map((d, i, arr) => (
                       <span key={d.key}>
-                        {d.label}{" "}
-                        <span className="font-semibold text-[#627D98]">{formatDateShort(domainFreshness![d.key]!)}</span>
+                        <DomainFreshnessItem
+                          label={d.label}
+                          dbDate={domainFreshness![d.key]!}
+                          freshness={freshnessBySource.get(d.sourceKey)}
+                        />
                         {i < arr.length - 1 && <span className="mx-1">·</span>}
                       </span>
                     ))}

--- a/components/layout/page-shell.tsx
+++ b/components/layout/page-shell.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { Header } from "./header";
-import type { DomainFreshness } from "@/lib/types";
+import type { DomainFreshness, SourceFreshness } from "@/lib/types";
 
 interface PageShellProps {
   title: string;
   subtitle?: string;
   lastUpdated?: string | null;
   domainFreshness?: DomainFreshness | null;
+  sourceFreshness?: SourceFreshness[];
   children: React.ReactNode;
 }
 
-export function PageShell({ title, subtitle, lastUpdated, domainFreshness, children }: PageShellProps) {
+export function PageShell({ title, subtitle, lastUpdated, domainFreshness, sourceFreshness, children }: PageShellProps) {
   return (
     <div className="min-h-screen bg-[#F4F6F8]">
-      <Header title={title} subtitle={subtitle} lastUpdated={lastUpdated} domainFreshness={domainFreshness} />
+      <Header title={title} subtitle={subtitle} lastUpdated={lastUpdated} domainFreshness={domainFreshness} sourceFreshness={sourceFreshness} />
       <div className="px-3 pb-6 md:px-4 xl:px-5 space-y-4">{children}</div>
       <footer className="px-3 py-4 md:px-4 xl:px-5 text-center text-[11px] text-[#627D98]">
         <span>Built by </span>

--- a/data/ingestion/freshness_check.py
+++ b/data/ingestion/freshness_check.py
@@ -1,0 +1,306 @@
+"""
+Source vs DB freshness check.
+
+For each data source, compare the max date available at the upstream API
+with the max date currently in the corresponding stg_* table. Classifies
+each source into one of:
+
+    ok              — DB is caught up with the source
+    source_lag      — source itself publishes with a delay (not our bug)
+    pipeline_behind — DB is meaningfully older than source (our bug)
+    unknown         — couldn't determine source or DB max (treat as warning)
+
+Results are upserted into pipeline_source_freshness for the UI/API to read.
+
+Exit code:
+    0 — no sources in 'pipeline_behind' state
+    1 — at least one source is in 'pipeline_behind' state (hard fail)
+
+Usage:
+    python data/ingestion/freshness_check.py
+"""
+
+import logging
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+
+import requests
+
+from arcgis_client import _request_with_retry
+from db import get_connection
+
+logger = logging.getLogger(__name__)
+
+# ── Thresholds ─────────────────────────────────────────────────────────
+#
+# DRIFT_THRESHOLD_DAYS: how far DB may fall behind source before we treat
+#   it as a pipeline regression. 2 days is generous enough to absorb cron
+#   timing jitter and weekends, strict enough to surface real bugs quickly.
+#
+# SOURCE_LAG_THRESHOLD_DAYS: if the source itself is older than this (vs.
+#   today), flag it as source_lag so the UI can differentiate it from a
+#   pipeline bug. Crashes dataset routinely runs 20-30d behind, so the
+#   threshold has to be >= 7 to avoid noise.
+DRIFT_THRESHOLD_DAYS = 2
+SOURCE_LAG_THRESHOLD_DAYS = 7
+
+# ── Source configuration ───────────────────────────────────────────────
+
+ARCGIS_SOURCES = [
+    {
+        "source": "crime",
+        "url": "https://services1.arcgis.com/zdB7qR0BtYrg0Xpl/arcgis/rest/services/ODC_CRIME_OFFENSES_P/FeatureServer/324",
+        "date_field": "REPORTED_DATE",
+        "stg_table": "stg_crime",
+        "stg_date_column": "reported_date",
+    },
+    {
+        "source": "crashes",
+        "url": "https://services1.arcgis.com/zdB7qR0BtYrg0Xpl/arcgis/rest/services/ODC_CRIME_TRAFFICACCIDENTS5YR_P/FeatureServer/325",
+        "date_field": "reported_date",
+        "stg_table": "stg_crashes",
+        "stg_date_column": "reported_date",
+    },
+    {
+        "source": "311",
+        "url": "https://services1.arcgis.com/zdB7qR0BtYrg0Xpl/arcgis/rest/services/ODC_service_requests_311/FeatureServer/66",
+        "date_field": "Case_Created_Date",
+        "stg_table": "stg_311",
+        "stg_date_column": "case_created_date",
+    },
+]
+
+AIRNOW_BASE_URL = "https://www.airnowapi.org/aq/observation/latLong/historical/"
+AIRNOW_TIMEOUT = 30
+
+
+# ── Source max date fetchers ───────────────────────────────────────────
+
+def fetch_arcgis_source_max(url: str, date_field: str) -> date | None:
+    """Query ArcGIS for MAX(date_field) via outStatistics (cheap, no bulk fetch)."""
+    params = {
+        "where": "1=1",
+        "outStatistics": (
+            f'[{{"statisticType":"max","onStatisticField":"{date_field}",'
+            f'"outStatisticFieldName":"max_date"}}]'
+        ),
+        "f": "json",
+    }
+    data = _request_with_retry(f"{url}/query", params)
+    if not data:
+        return None
+    features = data.get("features", [])
+    if not features:
+        return None
+    ts = features[0].get("attributes", {}).get("max_date")
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts / 1000, tz=timezone.utc).date()
+
+
+def fetch_airnow_source_max() -> date | None:
+    """
+    Probe AirNow for the most recent available observation.
+
+    AirNow historical endpoint publishes hourly observations with ~1-day
+    lag. We probe today first, fall back to yesterday. Whichever returns
+    data is the source_max.
+    """
+    api_key = os.environ.get("AIRNOW_API_KEY", "")
+    if not api_key:
+        logger.warning("AIRNOW_API_KEY not set — cannot determine AQI source freshness")
+        return None
+
+    today = datetime.now(tz=timezone.utc).date()
+    for days_back in range(0, 3):
+        probe_date = today - timedelta(days=days_back)
+        params = {
+            "format": "application/json",
+            "latitude": 39.7392,
+            "longitude": -104.9903,
+            "distance": 25,
+            "date": probe_date.strftime("%Y-%m-%dT00-0000"),
+            "API_KEY": api_key,
+        }
+        try:
+            resp = requests.get(AIRNOW_BASE_URL, params=params, timeout=AIRNOW_TIMEOUT)
+            resp.raise_for_status()
+            observations = resp.json()
+        except requests.RequestException as e:
+            logger.warning(f"AirNow probe for {probe_date} failed: {e}")
+            continue
+
+        # Any Denver observation is enough to confirm source freshness for this date.
+        denver_hits = [
+            o for o in observations
+            if o.get("ReportingArea") in ("Denver", "Denver-Boulder")
+        ]
+        if denver_hits:
+            return probe_date
+
+    return None
+
+
+# ── DB max date fetcher ────────────────────────────────────────────────
+
+def fetch_db_max(conn, table: str, date_column: str) -> date | None:
+    """SELECT MAX(date_column)::date FROM table."""
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT MAX({date_column})::date FROM {table}")  # noqa: S608
+        row = cur.fetchone()
+    return row[0] if row and row[0] else None
+
+
+# ── Classification ─────────────────────────────────────────────────────
+
+def classify(source_max: date | None, db_max: date | None, today: date) -> tuple[str, int | None, int | None]:
+    """
+    Return (status, drift_days, source_age_days).
+
+    drift_days = source_max - db_max (how far DB is behind source)
+    source_age_days = today - source_max (how far source is behind real time)
+    """
+    if source_max is None or db_max is None:
+        return "unknown", None, None
+
+    drift = (source_max - db_max).days
+    source_age = (today - source_max).days
+
+    if drift > DRIFT_THRESHOLD_DAYS:
+        return "pipeline_behind", drift, source_age
+    if source_age > SOURCE_LAG_THRESHOLD_DAYS:
+        return "source_lag", drift, source_age
+    return "ok", drift, source_age
+
+
+# ── Persist to DB ──────────────────────────────────────────────────────
+
+def upsert_freshness(conn, rows: list[dict]) -> None:
+    """Replace pipeline_source_freshness contents with the latest check results."""
+    with conn.cursor() as cur:
+        for r in rows:
+            cur.execute(
+                """
+                INSERT INTO pipeline_source_freshness
+                    (source, source_max_date, db_max_date, drift_days, status, source_age_days, checked_at)
+                VALUES (%s, %s, %s, %s, %s, %s, NOW())
+                ON CONFLICT (source) DO UPDATE SET
+                    source_max_date = EXCLUDED.source_max_date,
+                    db_max_date     = EXCLUDED.db_max_date,
+                    drift_days      = EXCLUDED.drift_days,
+                    status          = EXCLUDED.status,
+                    source_age_days = EXCLUDED.source_age_days,
+                    checked_at      = NOW()
+                """,
+                (
+                    r["source"],
+                    r["source_max_date"],
+                    r["db_max_date"],
+                    r["drift_days"],
+                    r["status"],
+                    r["source_age_days"],
+                ),
+            )
+    conn.commit()
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+def run_check() -> list[dict]:
+    """Run the full freshness check and return per-source results."""
+    today = datetime.now(tz=timezone.utc).date()
+    results: list[dict] = []
+
+    conn = get_connection()
+    try:
+        # ArcGIS sources
+        for cfg in ARCGIS_SOURCES:
+            src = cfg["source"]
+            logger.info(f"  Checking {src}...")
+            source_max = fetch_arcgis_source_max(cfg["url"], cfg["date_field"])
+            db_max = fetch_db_max(conn, cfg["stg_table"], cfg["stg_date_column"])
+            status, drift, age = classify(source_max, db_max, today)
+            results.append({
+                "source": src,
+                "source_max_date": source_max,
+                "db_max_date": db_max,
+                "drift_days": drift,
+                "source_age_days": age,
+                "status": status,
+            })
+
+        # AQI (AirNow)
+        logger.info("  Checking aqi...")
+        source_max = fetch_airnow_source_max()
+        db_max = fetch_db_max(conn, "stg_aqi", "observed_at")
+        status, drift, age = classify(source_max, db_max, today)
+        results.append({
+            "source": "aqi",
+            "source_max_date": source_max,
+            "db_max_date": db_max,
+            "drift_days": drift,
+            "source_age_days": age,
+            "status": status,
+        })
+
+        upsert_freshness(conn, results)
+    finally:
+        conn.close()
+
+    return results
+
+
+def format_report(results: list[dict]) -> str:
+    """Human-readable summary for logs."""
+    lines = ["", "FRESHNESS REPORT", "=" * 60]
+    for r in results:
+        icon = {
+            "ok": "OK  ",
+            "source_lag": "LAG ",
+            "pipeline_behind": "FAIL",
+            "unknown": "????",
+        }.get(r["status"], "????")
+        src = r["source"]
+        src_d = r["source_max_date"].isoformat() if r["source_max_date"] else "n/a"
+        db_d = r["db_max_date"].isoformat() if r["db_max_date"] else "n/a"
+        drift = r["drift_days"]
+        age = r["source_age_days"]
+        lines.append(
+            f"  [{icon}] {src:8s} source={src_d}  db={db_d}  "
+            f"drift={drift if drift is not None else '?'}d  "
+            f"source_age={age if age is not None else '?'}d"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [freshness] %(message)s",
+    )
+    logger.info("Running source freshness check")
+
+    try:
+        results = run_check()
+    except Exception as e:
+        logger.error(f"Freshness check failed: {e}", exc_info=True)
+        return 1
+
+    logger.info(format_report(results))
+
+    behind = [r for r in results if r["status"] == "pipeline_behind"]
+    if behind:
+        names = ", ".join(r["source"] for r in behind)
+        logger.error(
+            f"PIPELINE BEHIND source for: {names}. "
+            f"DB is more than {DRIFT_THRESHOLD_DAYS} days behind upstream."
+        )
+        return 1
+
+    logger.info("All sources are in sync (or source-lagged — not our bug).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/migrations/006_pipeline_source_freshness.sql
+++ b/data/migrations/006_pipeline_source_freshness.sql
@@ -1,0 +1,16 @@
+-- Per-source freshness tracking: compare source max_date against DB max_date.
+-- Upserted by data/ingestion/freshness_check.py on every pipeline run.
+-- Used to disambiguate "source is lagging" from "our pipeline is broken".
+
+CREATE TABLE IF NOT EXISTS pipeline_source_freshness (
+    source          TEXT        PRIMARY KEY,           -- 'crime' | 'crashes' | '311' | 'aqi'
+    source_max_date DATE,                              -- MAX(date) reported by the upstream API
+    db_max_date     DATE,                              -- MAX(date) in the corresponding stg_* table
+    drift_days      INTEGER,                           -- source_max_date - db_max_date (NULL if either is NULL)
+    status          TEXT        NOT NULL,              -- 'ok' | 'source_lag' | 'pipeline_behind' | 'unknown'
+    source_age_days INTEGER,                           -- today - source_max_date (how far the source itself lags)
+    checked_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_source_freshness_status
+    ON pipeline_source_freshness (status);

--- a/data/migrations/run_migrations.py
+++ b/data/migrations/run_migrations.py
@@ -72,6 +72,7 @@ def main():
             "mart_aqi_daily", "mart_neighborhood_comparison",
             "mart_narrative_signals",
             "ref_neighborhoods",
+            "pipeline_source_freshness",
         ]
 
         missing = [t for t in expected if t not in tables]

--- a/data/pipeline/run_daily.py
+++ b/data/pipeline/run_daily.py
@@ -76,6 +76,7 @@ def main():
         ("1_migrations", "migrations/run_migrations.py", BASE_DIR),
         ("2_ingestion", "ingestion/run_all.py", os.path.join(BASE_DIR, "ingestion")),
         ("3_marts", "marts/run_all.py", os.path.join(BASE_DIR, "marts")),
+        ("4_freshness_check", "ingestion/freshness_check.py", os.path.join(BASE_DIR, "ingestion")),
     ]
 
     results = []

--- a/data/pipeline/tests/test_freshness_check.py
+++ b/data/pipeline/tests/test_freshness_check.py
@@ -1,0 +1,169 @@
+"""Tests for source vs DB freshness classification logic."""
+
+import os
+import sys
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "ingestion"))
+
+from freshness_check import (  # noqa: E402
+    DRIFT_THRESHOLD_DAYS,
+    SOURCE_LAG_THRESHOLD_DAYS,
+    classify,
+    format_report,
+    main,
+)
+
+
+class TestClassify:
+    today = date(2026, 4, 5)
+
+    def test_ok_when_source_and_db_match(self):
+        status, drift, age = classify(
+            source_max=date(2026, 4, 4),
+            db_max=date(2026, 4, 4),
+            today=self.today,
+        )
+        assert status == "ok"
+        assert drift == 0
+        assert age == 1
+
+    def test_ok_when_drift_within_threshold(self):
+        # drift = 2 days, exactly at threshold → still ok
+        status, _, _ = classify(
+            source_max=date(2026, 4, 4),
+            db_max=date(2026, 4, 2),
+            today=self.today,
+        )
+        assert status == "ok"
+
+    def test_pipeline_behind_when_drift_exceeds_threshold(self):
+        # 7-day drift — this is the crime bug scenario
+        status, drift, _ = classify(
+            source_max=date(2026, 4, 2),
+            db_max=date(2026, 3, 26),
+            today=self.today,
+        )
+        assert status == "pipeline_behind"
+        assert drift == 7
+
+    def test_source_lag_when_source_behind_but_db_caught_up(self):
+        # crashes scenario: source has been stuck at Mar 9 for weeks,
+        # db matches it. Not our bug.
+        status, drift, age = classify(
+            source_max=date(2026, 3, 9),
+            db_max=date(2026, 3, 9),
+            today=self.today,
+        )
+        assert status == "source_lag"
+        assert drift == 0
+        assert age == 27
+
+    def test_unknown_when_source_missing(self):
+        status, drift, age = classify(
+            source_max=None,
+            db_max=date(2026, 4, 4),
+            today=self.today,
+        )
+        assert status == "unknown"
+        assert drift is None
+        assert age is None
+
+    def test_unknown_when_db_empty(self):
+        status, _, _ = classify(
+            source_max=date(2026, 4, 4),
+            db_max=None,
+            today=self.today,
+        )
+        assert status == "unknown"
+
+    def test_pipeline_behind_takes_priority_over_source_lag(self):
+        # Source is old (source_lag territory) AND our DB is even older
+        # (pipeline_behind territory). pipeline_behind wins.
+        status, drift, _ = classify(
+            source_max=date(2026, 3, 9),
+            db_max=date(2026, 2, 15),
+            today=self.today,
+        )
+        assert status == "pipeline_behind"
+        assert drift == 22
+
+    def test_thresholds_are_sane(self):
+        # Guard against someone accidentally lowering these to zero
+        assert DRIFT_THRESHOLD_DAYS >= 1
+        assert SOURCE_LAG_THRESHOLD_DAYS >= 3
+
+
+class TestFormatReport:
+    def test_renders_each_source(self):
+        results = [
+            {
+                "source": "crime",
+                "source_max_date": date(2026, 4, 2),
+                "db_max_date": date(2026, 4, 2),
+                "drift_days": 0,
+                "source_age_days": 3,
+                "status": "ok",
+            },
+            {
+                "source": "crashes",
+                "source_max_date": date(2026, 3, 9),
+                "db_max_date": date(2026, 3, 9),
+                "drift_days": 0,
+                "source_age_days": 27,
+                "status": "source_lag",
+            },
+        ]
+        report = format_report(results)
+        assert "crime" in report
+        assert "crashes" in report
+        assert "2026-04-02" in report
+        assert "2026-03-09" in report
+        assert "OK" in report
+        assert "LAG" in report
+
+    def test_handles_none_dates(self):
+        results = [{
+            "source": "aqi",
+            "source_max_date": None,
+            "db_max_date": None,
+            "drift_days": None,
+            "source_age_days": None,
+            "status": "unknown",
+        }]
+        report = format_report(results)
+        assert "aqi" in report
+        assert "n/a" in report
+
+
+class TestMainExitCode:
+    @patch("freshness_check.run_check")
+    def test_exits_0_when_all_ok(self, mock_run_check):
+        mock_run_check.return_value = [
+            {"source": "crime", "source_max_date": date(2026, 4, 2), "db_max_date": date(2026, 4, 2), "drift_days": 0, "source_age_days": 3, "status": "ok"},
+            {"source": "crashes", "source_max_date": date(2026, 3, 9), "db_max_date": date(2026, 3, 9), "drift_days": 0, "source_age_days": 27, "status": "source_lag"},
+        ]
+        assert main() == 0
+
+    @patch("freshness_check.run_check")
+    def test_exits_1_when_any_pipeline_behind(self, mock_run_check):
+        mock_run_check.return_value = [
+            {"source": "crime", "source_max_date": date(2026, 4, 2), "db_max_date": date(2026, 3, 26), "drift_days": 7, "source_age_days": 3, "status": "pipeline_behind"},
+            {"source": "crashes", "source_max_date": date(2026, 3, 9), "db_max_date": date(2026, 3, 9), "drift_days": 0, "source_age_days": 27, "status": "source_lag"},
+        ]
+        assert main() == 1
+
+    @patch("freshness_check.run_check")
+    def test_exits_0_when_unknown(self, mock_run_check):
+        # 'unknown' is a warning, not a hard fail. We don't want the pipeline
+        # failing because the check itself is broken.
+        mock_run_check.return_value = [
+            {"source": "aqi", "source_max_date": None, "db_max_date": None, "drift_days": None, "source_age_days": None, "status": "unknown"},
+        ]
+        assert main() == 0
+
+    @patch("freshness_check.run_check")
+    def test_exits_1_on_exception(self, mock_run_check):
+        mock_run_check.side_effect = RuntimeError("db down")
+        assert main() == 1

--- a/lib/hooks/use-city-pulse-data.ts
+++ b/lib/hooks/use-city-pulse-data.ts
@@ -8,6 +8,7 @@ import type {
   DomainFreshness,
   HeatmapCell,
   NeighborhoodRow,
+  SourceFreshness,
   TimeWindow,
 } from "@/lib/types";
 
@@ -20,6 +21,7 @@ interface CityPulseData {
   neighborhoods: NeighborhoodRow[];
   effectiveThrough: string | null;
   domainFreshness: DomainFreshness | null;
+  sourceFreshness: SourceFreshness[];
   lastUpdated: string | null;
   loading: boolean;
   error: string | null;
@@ -47,6 +49,7 @@ export function useCityPulseData(
     neighborhoods: [],
     effectiveThrough: null,
     domainFreshness: null,
+    sourceFreshness: [],
     lastUpdated: null,
     loading: true,
     error: null,
@@ -87,6 +90,7 @@ export function useCityPulseData(
         neighborhoods,
         effectiveThrough: kpisResp.effectiveThrough ?? null,
         domainFreshness: kpisResp.domainFreshness ?? null,
+        sourceFreshness: kpisResp.sourceFreshness ?? [],
         lastUpdated: kpisResp.lastUpdated ?? null,
         loading: false,
         error: null,

--- a/lib/queries/city-pulse.ts
+++ b/lib/queries/city-pulse.ts
@@ -1,5 +1,10 @@
 import { query } from "@/lib/db";
-import type { TimeWindow } from "@/lib/types";
+import type {
+  FreshnessSourceKey,
+  FreshnessStatus,
+  SourceFreshness,
+  TimeWindow,
+} from "@/lib/types";
 
 function daysForWindow(tw: TimeWindow): number {
   return tw === "7d" ? 7 : tw === "30d" ? 30 : 90;
@@ -318,6 +323,62 @@ export async function getDomainFreshness(): Promise<DomainFreshness> {
     crashes: map["crashes"] ?? null,
     requests311: map["311"] ?? null,
   };
+}
+
+// --- Source freshness (from pipeline_source_freshness table) ---
+
+// Map from DB source key to frontend TS key
+const SOURCE_KEY_MAP: Record<string, FreshnessSourceKey> = {
+  crime: "crime",
+  crashes: "crashes",
+  "311": "requests311",
+  aqi: "aqi",
+};
+
+interface SourceFreshnessRow {
+  source: string;
+  source_max_date: string | null;
+  db_max_date: string | null;
+  drift_days: number | null;
+  source_age_days: number | null;
+  status: string;
+  checked_at: string | null;
+}
+
+export async function getSourceFreshness(): Promise<SourceFreshness[]> {
+  try {
+    const rows = await query<SourceFreshnessRow>(
+      `SELECT source,
+              source_max_date::text AS source_max_date,
+              db_max_date::text     AS db_max_date,
+              drift_days,
+              source_age_days,
+              status,
+              checked_at::text      AS checked_at
+       FROM pipeline_source_freshness`
+    );
+
+    return rows
+      .map((r) => {
+        const key = SOURCE_KEY_MAP[r.source];
+        if (!key) return null;
+        return {
+          source: key,
+          dbDate: r.db_max_date,
+          sourceDate: r.source_max_date,
+          driftDays: r.drift_days,
+          sourceAgeDays: r.source_age_days,
+          status: (r.status as FreshnessStatus) ?? "unknown",
+          checkedAt: r.checked_at,
+        };
+      })
+      .filter((r): r is SourceFreshness => r !== null);
+  } catch {
+    // Table missing (fresh DB pre-migration) or transient DB error — treat as
+    // "no freshness info available" so the dashboard still loads. The hard
+    // fail in freshness_check.py is the source of truth for alerting.
+    return [];
+  }
 }
 
 // --- Category Trends (sparklines per category) ---

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,20 @@ export interface DomainFreshness {
   aqi: string | null;
 }
 
+export type FreshnessStatus = "ok" | "source_lag" | "pipeline_behind" | "unknown";
+
+export type FreshnessSourceKey = "crime" | "crashes" | "requests311" | "aqi";
+
+export interface SourceFreshness {
+  source: FreshnessSourceKey;
+  dbDate: string | null;
+  sourceDate: string | null;
+  driftDays: number | null;
+  sourceAgeDays: number | null;
+  status: FreshnessStatus;
+  checkedAt: string | null;
+}
+
 export interface DateRange {
   from: string;
   to: string;


### PR DESCRIPTION
## Summary

Adds a new pipeline stage that compares the latest date available at each upstream source (ArcGIS `outStatistics` for crime/crashes/311, AirNow probe for AQI) against the max date in the corresponding `stg_*` table. Results are upserted into a new `pipeline_source_freshness` table and surfaced in the dashboard header with hover tooltips.

**Motivation:** the recent ArcGIS ms-timestamp regression (#238) was a silent failure — ingestion returned 0 records for a week without any alert. This change makes silent ingestion bugs immediately visible as failed Railway deploys.

## Classification

| Status | Meaning | Exit code |
|--------|---------|-----------|
| `ok` | DB matches source | 0 |
| `source_lag` | Source itself publishes with delay (crashes scenario) | 0 |
| `pipeline_behind` | DB is >2 days behind source — **our bug** | **1 (hard fail)** |
| `unknown` | Check couldn't run (warning only, not an alert trigger) | 0 |

## Backend

- New migration `006_pipeline_source_freshness.sql` — table with `source`, `source_max_date`, `db_max_date`, `drift_days`, `source_age_days`, `status`, `checked_at`
- New script `data/ingestion/freshness_check.py`:
  - ArcGIS: queries `MAX(date)` via `outStatistics` (single aggregate call, no bulk fetch)
  - AirNow: probes today → yesterday → day-before for any Denver observation
  - Writes 4 rows to `pipeline_source_freshness`, exits 1 if any `pipeline_behind`
- `run_daily.py`: new 4th stage `4_freshness_check` runs after marts, propagates exit code

## Frontend

- New types in `lib/types.ts`: `SourceFreshness`, `FreshnessStatus`, `FreshnessSourceKey`
- `getSourceFreshness()` in `lib/queries/city-pulse.ts` with try/catch fallback to `[]` (graceful degradation if table missing or DB error — dashboard keeps working)
- `/api/city-pulse/kpis` includes `sourceFreshness[]` in response
- `Header` renders `DomainFreshnessItem` for each domain:
  - Hover tooltip shows: In DB date · At source date · status line
  - Small gray dot next to label → `source_lag`
  - Small orange dot → `pipeline_behind`
  - No marker → `ok`

## Verification

- `npm test` — 110 passed, 2 skipped, 12 suites ✅
- `npm run lint` — clean ✅
- `npm run build` — compiles, TypeScript OK ✅
- `.venv/bin/python -m pytest data/pipeline/tests` — 43 passed (14 new for `freshness_check`) ✅
- Live ArcGIS smoke test of `fetch_arcgis_source_max()` returned accurate max dates for all three endpoints

## Expected state after merge + first cron run

| Source | Status | Why |
|--------|--------|-----|
| crime | `ok` | Source and DB both Apr 2 |
| crashes | `source_lag` | Source stuck at Mar 9, DB matches — tooltip explains ~27d upstream delay |
| 311 | `ok` | Source and DB both Mar 31 |
| aqi | `ok` | AirNow refreshed daily |

Railway deploy will stay green. Any future silent ingestion bug → exit 1 → red deploy → immediate signal.

## Test plan

- [x] Python unit tests for classification, exit codes, report formatting
- [x] Frontend unit tests for tooltip content per status
- [x] API response shape test (including empty array fallback when table is missing)
- [x] Build and lint pass
- [ ] Post-merge: verify Railway cron green + dashboard tooltip renders
- [ ] Post-merge: manually simulate `pipeline_behind` (e.g. `UPDATE stg_crime SET reported_date = reported_date - INTERVAL '10 days'`) and confirm freshness_check exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)